### PR TITLE
Stop triggering table sort when adjusting filter slider

### DIFF
--- a/web/gui-v2/src/components/HeaderSlider.jsx
+++ b/web/gui-v2/src/components/HeaderSlider.jsx
@@ -52,6 +52,7 @@ const HeaderSlider = ({
       <Slider
         css={styles.slider}
         onChange={(newVal) => setValueInternal(newVal.target.value)}
+        onClick={(event) => event.stopPropagation()}
         size="small"
         value={valueInternal}
         valueLabelDisplay="auto"


### PR DESCRIPTION
Prevent propagation of click events when the user adjusts the filter slider, thereby preventing unintentional toggling of the column sort.

Closes #22