### PR TITLE
Fix bug where incorrect initial columns were selected

### DIFF
--- a/web/gui-v2/src/components/AddRemoveColumnDialog.jsx
+++ b/web/gui-v2/src/components/AddRemoveColumnDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import {
   Checkbox,
@@ -49,6 +49,11 @@ const styles = {
   `,
 };
 
+const generateColumnState = (selected, defs) => {
+  const split = selected.split(',');
+  return Object.fromEntries(defs.map(e => [e.key, split.includes(e.key)]));
+}
+
 const AddRemoveColumnDialog = ({
   columnDefinitions,
   isOpen,
@@ -57,9 +62,15 @@ const AddRemoveColumnDialog = ({
   updateSelectedColumns,
 }) => {
   const [columnsInternal, setColumnsInternal] = useState(() => {
-    const split = selectedColumns.split(',');
-    return Object.fromEntries(columnDefinitions.map(e => [e.key, split.includes(e.key)]));
+    return generateColumnState(selectedColumns, columnDefinitions);
   });
+
+  useEffect(
+    () => {
+      setColumnsInternal(generateColumnState(selectedColumns, columnDefinitions));
+    },
+    [columnDefinitions, selectedColumns]
+  );
 
   const handleCancel = () => {
     updateIsOpen(false);


### PR DESCRIPTION
Update the initial selections of columns to properly reflect the already-selected columns on first load of the Add/Remove Columns dialog.

Previously, adjusting columns and then reloading the page (or loading from the start with `zz_columns` set) would lead to the Add/Remove Column dialog loading with _all_ columns selected (the defaults), not the currently specified columns.

Closes #29