### PR TITLE
Run rebase bot on trunk branches

### DIFF
--- a/.github/workflows/rebase-reminder.yml
+++ b/.github/workflows/rebase-reminder.yml
@@ -1,5 +1,12 @@
 name: Rebase reminder
-on: [pull_request, pull_request_review]
+on:
+  pull_request:
+  pull_request_review:
+  push:
+    branches:
+      - main
+      - master
+      - version2
 
 jobs:
   build:


### PR DESCRIPTION
Run the rebase reminder bot on pull requests (as it has), but also when pushing to trunk branches (`main`, `master`, and, for PARAT, `version2`)

Based on how/when the visual testing workflow runs