### PR TITLE
Revert "Merge pull request #45 from georgetown-cset/rebasebot-on-trunk-branches"

### DIFF
--- a/.github/workflows/rebase-reminder.yml
+++ b/.github/workflows/rebase-reminder.yml
@@ -1,12 +1,5 @@
 name: Rebase reminder
-on:
-  pull_request:
-  pull_request_review:
-  push:
-    branches:
-      - main
-      - master
-      - version2
+on: [pull_request, pull_request_review]
 
 jobs:
   build:


### PR DESCRIPTION
Revert "Merge pull request #45 from georgetown-cset/rebasebot-on-trunk-branches"

This reverts commit 989ee73893a53cec68bd58c268fc9161073be281, reversing changes made to e8ab9cbfd9057e718cd8ecec5a82c95d8c20846a.

Running the rebase reminder workflow on `push` doesn't work because the pull request's head/base info isn't included in the action payload.