### PR TITLE
Increase memory for deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,8 @@ jobs:
         npm run artifactregistry-login
         npm install
     - name: 'Build assets'
+      env:
+        NODE_OPTIONS: "--max_old_space_size=4096"
       working-directory: web/gui-v2
       run: |
         npm install -g gatsby-cli


### PR DESCRIPTION
Increase memory for the deployment workflow in line with prior increases for the other workflows (see 619c775) to hopefully resolve a deployment failure (see https://github.com/georgetown-cset/parat/actions/runs/6026061566/job/16348162555).