### PR TITLE
Stop tracking test coverage of `pages/` directory

### DIFF
--- a/web/gui-v2/jest.config.js
+++ b/web/gui-v2/jest.config.js
@@ -29,6 +29,7 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: [
     'src/**/*.{js,jsx}',
+    '!src/pages/**',
     '!**/*.test.*',
     '!**/__tests__/**',
   ],


### PR DESCRIPTION
The components used in the `pages/` directory are more effectively tested directly, so don't include `pages/` in the test coverage report.