### PR TITLE
Adjust styles when no companies are found

### DIFF
--- a/web/gui-v2/src/components/HeaderDropdown.jsx
+++ b/web/gui-v2/src/components/HeaderDropdown.jsx
@@ -10,10 +10,17 @@ const styles = {
     .MuiFormControl-root {
       width: 100%;
     }
+
+    .MuiAutocomplete-option {
+      padding: 6px;
+    }
   `,
 };
 
 const HeaderDropdown = ({
+  className: appliedClassName,
+  css: appliedCss,
+  id: appliedId,
   label,
   multiple=true,
   options,
@@ -25,7 +32,9 @@ const HeaderDropdown = ({
 
   return (
     <Autocomplete
-      css={styles.headerDropdown}
+      className={appliedClassName}
+      css={[styles.headerDropdown, appliedCss]}
+      id={appliedId}
       inputLabel={label}
       multiple={multiple}
       options={optionsInternal}

--- a/web/gui-v2/src/components/ListViewTable.jsx
+++ b/web/gui-v2/src/components/ListViewTable.jsx
@@ -73,8 +73,6 @@ const styles = {
     }
 
     th .MuiButtonBase-root {
-      /* width: 100%; */
-
       input.MuiInputBase-input {
         width: 100%;
       }
@@ -83,10 +81,10 @@ const styles = {
         width: 100%;
       }
     }
-
-    .table--content {
-      /* This is set so that the Dropdown menus in the table headers will extend beyond '.table-content' */
-      overflow-x: initial;
+  `,
+  shortDropdown: css`
+    .MuiPaper-root {
+      max-height: 192px;
     }
   `,
   fallbackContent: css`
@@ -94,7 +92,7 @@ const styles = {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    padding: 1rem;
+    padding: 4rem 1rem;
 
     big {
       font-size: 150%;
@@ -398,6 +396,7 @@ const ListViewTable = ({
         case 'dropdown':
           display_name = (
             <HeaderDropdown
+              css={dataForTable.length === 0 && styles.shortDropdown}
               label={colDef.title}
               options={narrowedFilterOptions?.[colDef.key]}
               selected={filters?.[colDef.key].get}


### PR DESCRIPTION
Adjust the styles of the "no companies found" message box and the dropdown menus so that the dropdown menus aren't cutoff by the table boundary while still allowing proper scrolling of wide table contents.

Resolves issue from 2023-09-11 PARAT meeting

