### PR TITLE
Remove stock ticker from title and adjust font

### DIFF
--- a/web/gui-v2/src/components/DetailView.jsx
+++ b/web/gui-v2/src/components/DetailView.jsx
@@ -35,7 +35,7 @@ const styles = {
 
     .MuiBreadcrumbs-li,
     .MuiTypography-root {
-      font-family: GTZirkonRegular;
+      font-family: GTZirkonLight;
     }
   `,
   error: css`
@@ -122,14 +122,7 @@ const DetailView = ({
             />
           }
           headingComponent="h1"
-          title={
-            <>
-              {companyData.name}
-              {companyData.market_filt && companyData.market_filt.length > 0 &&
-                <> <small className="stock-ticker">({companyData.market_filt.map(ticker => ticker.market_key).join(', ')})</small></>
-              }
-            </>
-          }
+          title={companyData.name}
         >
           <div css={styles.contentsWrapper}>
             {windowSize >= breakpointStops.medium &&


### PR DESCRIPTION
Adjust the font in the breadcrumb links (closes #79) and remove the stock ticker(s) from the title section (closes #80).