### PR TITLE
Revise company metadata table and add dialog with more data

### DIFF
--- a/web/gui-v2/src/components/DetailViewIntro.jsx
+++ b/web/gui-v2/src/components/DetailViewIntro.jsx
@@ -1,7 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { css } from '@emotion/react';
 
-import { ExternalLink, Table, breakpoints } from '@eto/eto-ui-components';
+import {
+  ButtonStyled,
+  ExternalLink,
+  breakpoints,
+} from '@eto/eto-ui-components';
+
+import MoreMetadataDialog from './DetailViewMoreMetadataDialog';
+import TwoColumnTable from './TwoColumnTable';
 
 const styles = {
   detailIntroWrapper: css`
@@ -37,44 +44,32 @@ const styles = {
       padding: 0.5rem;
     }
   `,
+  buttonWrapper: css`
+    display: flex;
+    margin-top: 1rem !important;
+
+    button {
+      margin-left: auto;
+    }
+  `,
 };
 
 const DetailViewIntro = ({
   companyId,
   data,
 }) => {
+  const [dialogOpen, setDialogOpen] = useState(false);
 
-  const metadataColumns = [
-    { display_name: "", key: "title" },
-    {
-      display_name: "",
-      key: "data",
-      align: "right",
-      format: (val, row) => {
-        if ( row.title === "Website" ) {
-          return <ExternalLink href={val}>{val}</ExternalLink>;
-        } else if ( row.title === "Stock tickers" ) {
-          return val.map(e => <ExternalLink href={e.link}>{e.market_key}</ExternalLink>);
-        } else {
-          return val;
-        }
-      },
-    },
-  ];
-
-  const metadataData = [
-    { title: "Aliases", data: data.name },
-    { title: "Country", data: data.country },
-    { title: "Region", data: data.continent },
-    { title: "Stage", data: data.stage },
-    // { title: "Groupings", data: "S&P 500" },
-    { title: "Website", data: data.website },
+  const metadata = [
+    { title: "Country", value: data.country },
+    { title: "Sector", value: "--TODO--" },
+    { title: "Website", value: data.website ? <ExternalLink href={data.website}>{data.website}</ExternalLink> : undefined },
   ];
 
   if ( data.market_filt && data.market_filt.length > 0 ) {
-    metadataData.push({
+    metadata.push({
       title: "Stock tickers",
-      data: data.market_filt,
+      value: data.market_filt.map((e) => <ExternalLink href={e.link}>{e.market_key}</ExternalLink>),
     });
   }
 
@@ -92,12 +87,19 @@ const DetailViewIntro = ({
           <div>No description available</div>
         }
       </div>
-      <Table
-        className="metadata-table"
-        columns={metadataColumns}
-        css={styles.metadataTable}
-        data={metadataData}
-        showHeader={false}
+      <div>
+        <TwoColumnTable data={metadata} />
+
+        <div css={styles.buttonWrapper}>
+          <ButtonStyled onClick={() => setDialogOpen(true)}>
+            View more metadata
+          </ButtonStyled>
+        </div>
+      </div>
+      <MoreMetadataDialog
+        data={data}
+        isOpen={dialogOpen}
+        updateIsOpen={setDialogOpen}
       />
     </div>
   );

--- a/web/gui-v2/src/components/DetailViewIntro.jsx
+++ b/web/gui-v2/src/components/DetailViewIntro.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
-import { Table, breakpoints } from '@eto/eto-ui-components';
+import { ExternalLink, Table, breakpoints } from '@eto/eto-ui-components';
 
 const styles = {
   detailIntroWrapper: css`
@@ -46,7 +46,20 @@ const DetailViewIntro = ({
 
   const metadataColumns = [
     { display_name: "", key: "title" },
-    { display_name: "", key: "data", align: "right" },
+    {
+      display_name: "",
+      key: "data",
+      align: "right",
+      format: (val, row) => {
+        if ( row.title === "Website" ) {
+          return <ExternalLink href={val}>{val}</ExternalLink>;
+        } else if ( row.title === "Stock tickers" ) {
+          return val.map(e => <ExternalLink href={e.link}>{e.market_key}</ExternalLink>);
+        } else {
+          return val;
+        }
+      },
+    },
   ];
 
   const metadataData = [
@@ -55,8 +68,15 @@ const DetailViewIntro = ({
     { title: "Region", data: data.continent },
     { title: "Stage", data: data.stage },
     // { title: "Groupings", data: "S&P 500" },
-    { title: "Stock tickers", data: data.market_list },
+    { title: "Website", data: data.website },
   ];
+
+  if ( data.market_filt && data.market_filt.length > 0 ) {
+    metadataData.push({
+      title: "Stock tickers",
+      data: data.market_filt,
+    });
+  }
 
   return (
     <div css={styles.detailIntroWrapper}>

--- a/web/gui-v2/src/components/DetailViewMoreMetadataDialog.jsx
+++ b/web/gui-v2/src/components/DetailViewMoreMetadataDialog.jsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { Dialog, DialogTitle } from '@mui/material';
+
+import { ButtonStyled, ExternalLink } from '@eto/eto-ui-components';
+
+import TwoColumnTable from './TwoColumnTable';
+
+const styles = {
+  dialog: css`
+    .MuiPaper-root {
+      background-color: var(--bright-blue-light);
+    }
+  `,
+  dialogTitle: css`
+    font-family: GTZirkonRegular;
+    text-align: center;
+  `,
+  dialogInnerWrapper: css`
+    font-family: GTZirkonLight;
+    padding: 0 0.5rem 0.5rem;
+  `,
+  dialogContents: css`
+    background-color: var(--bright-blue-lightest);
+    max-height: calc(100vh - 200px);
+    overflow-y: auto;
+    padding: 0.5rem;
+  `,
+  table: css`
+    th,
+    td {
+      background-color: var(--bright-blue-lightest);
+    }
+  `,
+  linkWrapper: css`
+    display: flex;
+    flex-direction: column;
+  `,
+  dialogBottom: css`
+    display: flex;
+    justify-content: center;
+    margin-top: 0.5rem;
+  `,
+};
+
+/**
+ * A dialog for displaying more metadata about a particular company.
+ *
+ * @param {object} props
+ * @param {object} props.data
+ * @param {boolean} props.isOpen
+ * @param {(newState: boolean) => void} props.updateIsOpen
+ * @returns {JSX.Element}
+ */
+const MoreMetadataDialog = ({
+  data,
+  isOpen,
+  updateIsOpen,
+}) => {
+  const metadata = [
+    { title: 'Name', value: data.name },
+    { title: 'Aliases', value: data.aliases },
+    { title: 'Country', value: data.country },
+    { title: 'Continent', value: data.continent },
+    { title: 'Website', value: data.website ? <ExternalLink href={data.website}>{data.website}</ExternalLink> : undefined },
+    {
+      title: 'Crunchbase',
+      value: <div css={styles.linkWrapper}>
+        <ExternalLink href={data.crunchbase.crunchbase_url}>{data.crunchbase.crunchbase_url}</ExternalLink>
+        {data.child_crunchbase.map(e => <ExternalLink href={e.crunchbase_url}>{e.crunchbase_url}</ExternalLink>)}
+      </div>
+    },
+    {
+      title: 'LinkedIn',
+      value: <div css={styles.linkWrapper}>
+        {data.linkedin.map(e => <ExternalLink href={e}>{e}</ExternalLink>)}
+      </div>
+    },
+    { title: 'In S&P 500?', value: data.in_sandp_500 ? 'Yes' : 'No' },
+    { title: 'In Fortune Global 500?', value: data.in_fortune_global_500 ? 'Yes' : 'No' },
+    { title: 'Stage', value: data.stage },
+    { title: 'Full market links', value: 'TODO - data are currently in an `__html` object' },
+  ];
+
+  const handleClose = () => {
+    updateIsOpen(false);
+  };
+
+  return (
+    <Dialog
+      css={styles.dialog}
+      open={isOpen}
+      onClose={() => updateIsOpen(false)}
+    >
+      <DialogTitle css={styles.dialogTitle}>
+        { data.name } details
+      </DialogTitle>
+      <div css={styles.dialogInnerWrapper}>
+        <div css={styles.dialogContents}>
+          <TwoColumnTable
+            css={styles.table}
+            data={metadata}
+          />
+        </div>
+        <div css={styles.dialogBottom}>
+          <ButtonStyled onClick={handleClose} variant="contained">
+            Close
+          </ButtonStyled>
+        </div>
+      </div>
+    </Dialog>
+  );
+};
+
+export default MoreMetadataDialog;

--- a/web/gui-v2/src/components/TwoColumnTable.jsx
+++ b/web/gui-v2/src/components/TwoColumnTable.jsx
@@ -30,6 +30,10 @@ const styles = {
       text-align: right;
     }
   `,
+  notFound: css`
+    color: var(--grey);
+    font-style: italic;
+  `,
 };
 
 const TwoColumnTable = ({
@@ -54,7 +58,7 @@ const TwoColumnTable = ({
         {data.map((row) => (
           <tr>
             <th scope="row">{row.title}</th>
-            <td>{row.value}</td>
+            <td>{row.value ?? <span css={styles.notFound}>None found</span>}</td>
           </tr>
         ))}
       </tbody>

--- a/web/gui-v2/src/components/TwoColumnTable.jsx
+++ b/web/gui-v2/src/components/TwoColumnTable.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { css } from '@emotion/react';
+
+import { classes } from '@eto/eto-ui-components';
+
+const styles = {
+  table: css`
+    border-collapse: collapse;
+    border-spacing: 0;
+    display: table;
+    font-family: GTZirkonLight;
+    letter-spacing: 0.01071em;
+    line-height: 1.43;
+    width: 100%;
+
+    th,
+    td {
+      background-color: white;
+      border: 1px solid var(--bright-blue);
+      font-size: 0.875rem;
+      padding: 0.5rem;
+    }
+
+    th {
+      font-weight: normal;
+      text-align: left;
+    }
+
+    td {
+      text-align: right;
+    }
+  `,
+};
+
+const TwoColumnTable = ({
+  className: appliedClassName,
+  css: appliedCss,
+  data,
+  id: appliedId,
+}) => {
+  return (
+    <table
+      className={classes([
+        'two-column-table',
+        appliedClassName,
+      ])}
+      css={[
+        styles.table,
+        appliedCss,
+      ]}
+      id={appliedId}
+    >
+      <tbody>
+        {data.map((row) => (
+          <tr>
+            <th scope="row">{row.title}</th>
+            <td>{row.value}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default TwoColumnTable;


### PR DESCRIPTION
Update the fields displayed in the detail view's metadata table.  Add a dialog box to display additional fields.

Closes #81

### Pending
* [ ] [Main view] Still need data for the "Sector" table entry (see #120)
* [ ] [Dialog] The data in `data.full_market_links` are currently raw HTML objects instead of just the plain URLs (see #18)