### PR TITLE
Update detail page based on mockups

### DIFF
--- a/web/gui-v2/src/components/DetailView.jsx
+++ b/web/gui-v2/src/components/DetailView.jsx
@@ -100,10 +100,10 @@ const DetailView = ({
 
   if ( companyData ) {
     const breadcrumbs = [
-      <GatsbyLink to="/#table">
+      <GatsbyLink to="/#table" key="root">
         ETO PARAT
       </GatsbyLink>,
-      <Typography>
+      <Typography key={companyId}>
         {companyData.name}
       </Typography>
     ];

--- a/web/gui-v2/src/components/DetailViewChart.jsx
+++ b/web/gui-v2/src/components/DetailViewChart.jsx
@@ -1,6 +1,7 @@
 import React, { Suspense, lazy } from 'react';
 import { css } from '@emotion/react';
 
+import SectionHeading from './SectionHeading';
 import { fallback } from '../styles/common-styles';
 
 const Plot = lazy(() => import('react-plotly.js'));
@@ -16,27 +17,22 @@ const styles = {
     margin: 0.5rem auto 0;
     max-width: 1000px;
   `,
-  chartTitle: css`
-    font-family: GTZirkonMedium;
-    font-size: 24px;
-    margin-bottom: 0;
-    text-align: center;
-  `,
 };
 
 
 const Chart = ({
   config,
   data,
+  id,
   layout,
   title,
 }) => {
   return (
     !isSSR &&
     <Suspense fallback={<div css={fallback}>Loading graph...</div>}>
-      <h3 css={styles.chartTitle}>
+      <SectionHeading id={id}>
         {title}
-      </h3>
+      </SectionHeading>
       <div css={styles.chartContainer}>
         <Plot
           data={data}

--- a/web/gui-v2/src/components/DetailViewIntro.jsx
+++ b/web/gui-v2/src/components/DetailViewIntro.jsx
@@ -69,7 +69,7 @@ const DetailViewIntro = ({
   if ( data.market_filt && data.market_filt.length > 0 ) {
     metadata.push({
       title: "Stock tickers",
-      value: data.market_filt.map((e) => <ExternalLink href={e.link}>{e.market_key}</ExternalLink>),
+      value: data.market_filt.map((e) => <ExternalLink href={e.link} key={e.market_key}>{e.market_key}</ExternalLink>),
     });
   }
 

--- a/web/gui-v2/src/components/DetailViewMoreMetadataDialog.jsx
+++ b/web/gui-v2/src/components/DetailViewMoreMetadataDialog.jsx
@@ -67,13 +67,13 @@ const MoreMetadataDialog = ({
       title: 'Crunchbase',
       value: <div css={styles.linkWrapper}>
         <ExternalLink href={data.crunchbase.crunchbase_url}>{data.crunchbase.crunchbase_url}</ExternalLink>
-        {data.child_crunchbase.map(e => <ExternalLink href={e.crunchbase_url}>{e.crunchbase_url}</ExternalLink>)}
+        {data.child_crunchbase.map(e => <ExternalLink href={e.crunchbase_url} key={e.crunchbase_url}>{e.crunchbase_url}</ExternalLink>)}
       </div>
     },
     {
       title: 'LinkedIn',
       value: <div css={styles.linkWrapper}>
-        {data.linkedin.map(e => <ExternalLink href={e}>{e}</ExternalLink>)}
+        {data.linkedin.map(e => <ExternalLink href={e} key={e}>{e}</ExternalLink>)}
       </div>
     },
     { title: 'In S&P 500?', value: data.in_sandp_500 ? 'Yes' : 'No' },

--- a/web/gui-v2/src/components/DetailViewPatents.jsx
+++ b/web/gui-v2/src/components/DetailViewPatents.jsx
@@ -17,7 +17,7 @@ const styles = {
     max-width: 808px;
 
     h3 {
-      margin-bottom: 0.25rem;
+      margin-bottom: 0.5rem;
     }
   `,
 };

--- a/web/gui-v2/src/components/DetailViewPatents.jsx
+++ b/web/gui-v2/src/components/DetailViewPatents.jsx
@@ -1,9 +1,26 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { css } from '@emotion/react';
 
-import Chart from './DetailViewChart';
+import { Dropdown } from '@eto/eto-ui-components';
+
 import HeaderWithLink from './HeaderWithLink';
+import StatGrid from './StatGrid';
+import TableSection from './TableSection';
+import TextAndBigStat from './TextAndBigStat';
+import TrendsChart from './TrendsChart';
+import { commas } from '../util';
 import { assemblePlotlyParams } from '../util/plotly-helpers';
 
+const styles = {
+  section: css`
+    margin: 2rem auto 1rem;
+    max-width: 808px;
+
+    h3 {
+      margin-bottom: 0.25rem;
+    }
+  `,
+};
 
 const chartLayoutChanges = {
   legend: {
@@ -16,62 +33,129 @@ const chartLayoutChanges = {
   },
 };
 
-const PATENT_CHART_LEGEND_GROUPINGS = {
-  ai_patents: 'col-1',
-  Security__eg_cybersecurity: 'col-1',
-  Education: 'col-1',
-  Networks__eg_social_IOT_etc: 'col-1',
-  Business: 'col-1',
-
-  Military: 'col-2',
-  Agricultural: 'col-2',
-  Life_Sciences: 'col-2',
-  Entertainment: 'col-2',
-  Transportation: 'col-2',
-
-  Semiconductors: 'col-3',
-  Nanotechnology: 'col-3',
-  Energy_Management: 'col-3',
-  Banking_and_Finance: 'col-3',
-  Telecommunications: 'col-3',
-
-  Computing_in_Government: 'col-4',
-  Industrial_and_Manufacturing: 'col-4',
-  Physical_Sciences_and_Engineering: 'col-4',
-  Document_Mgt_and_Publishing: 'col-4',
-  Personal_Devices_and_Computing: 'col-4',
-};
-
 const DetailViewPatents = ({
   data,
 }) => {
-  const patentsData = Object.entries(PATENT_CHART_LEGEND_GROUPINGS)
-    .map(([key, group]) => {
-      const { name, counts } = data.patents[key];
-      return [name.replace(/ patents/i, ''), counts, { legendgroup: group }];
-    });
+  const [aiSubfield, setAiSubfield] = useState("ai_patents");
 
-  const patentsChart = assemblePlotlyParams(
-    "AI patents over time",
+  const statGridEntries = [
+    {
+      stat: <>#{commas(data.patents.ai_patents.rank)}</>,
+      text: <>in PARAT for number of AI-related patents</>,
+    },
+    {
+      stat: <>NUM%</>,
+      text: <>growth in {data.name}'s AI patenting (YEAR-YEAR)</>,
+    },
+    {
+      stat: <>NUM</>,
+      text: <div>AI patent <strong>applications</strong> were filed by {data.name} (YEAR_YEAR)</div>,
+    },
+    {
+      stat: <>NUM%</>,
+      text: <>of {data.name}'s total patenting was AI-focused</>,
+    },
+  ];
+
+  const numYears = data.years.length;
+  const startIx = numYears - 7;
+  const endIx = numYears - 2;
+  const patentTableColumns = [
+    { display_name: "Subfield", key: "subfield" },
+    { display_name: "Patents granted", key: "patents" },
+    { display_name: <>Growth ({data.years[startIx]}&ndash;{data.years[endIx]})</>, key: "growth" },
+  ];
+
+  const patentSubkeys = Object.keys(data.patents);
+
+  // NOTE: for the time being, I'm hardcoding these to get data to display.  The
+  // final implementation will require discussion and coordination.
+  const patentApplicationAreas = patentSubkeys.slice(0, 5).map((key) => {
+    const startVal = data.patents[key].counts[startIx];
+    const endVal = data.patents[key].counts[endIx];
+    const growth = `${Math.round((endVal - startVal) / startVal * 1000) / 10}%`;
+    return {
+      subfield: data.patents[key].name,
+      patents: data.patents[key].total,
+      growth,
+    };
+  });
+
+  const patentIndustryAreas = patentSubkeys.slice(5, 10).map((key) => {
+    const startVal = data.patents[key].counts[startIx];
+    const endVal = data.patents[key].counts[endIx];
+    const growth = `${Math.round((endVal - startVal) / startVal * 1000) / 10}%`;
+    return {
+      subfield: data.patents[key].name,
+      patents: data.patents[key].total,
+      growth,
+    };
+  });
+
+  const aiSubfieldOptions = [
+    { text: "AI (all subtopics)", val: "ai_patents" },
+    // NOTE: Disable the other subtopics for now since the keys aren't in the data.
+    // { text: "Computer vision", val: "cv_patents" },
+    // { text: "Natural language processing", val: "nlp_patents" },
+    // { text: "Robotics", val: "robotics_patents" },
+  ];
+
+  const aiSubfieldChartData = assemblePlotlyParams(
+    "Trends in research....",
     data.years,
-    patentsData,
+    [
+      [
+        aiSubfieldOptions.find(e => e.val === aiSubfield)?.text,
+        data.patents[aiSubfield].counts
+      ],
+    ],
     chartLayoutChanges,
   );
-
 
   return (
     <>
       <HeaderWithLink title="Patents" />
 
-      <p>
-        Radio telescope light years extraplanetary the sky calls to us billions
-        upon billions cosmic ocean. The only home we've ever known tesseract
-        tesseract dream of the mind's eye Apollonius of Perga take root and
-        flourish? Euclid realm of the galaxies inconspicuous motes of rock and
-        gas great turbulent clouds decipherment network of wormholes.
-      </p>
+      <TextAndBigStat
+        smallText={<>Between {data.years[0]} and {data.years[data.years.length-1]}, {data.name} obtained</>}
+        bigText={<>{commas(data.patents.ai_patents.total)} AI patents</>}
+      />
 
-      <Chart {...patentsChart} />
+      <StatGrid entries={statGridEntries} />
+
+      <TableSection
+        columns={patentTableColumns}
+        css={styles.section}
+        data={patentApplicationAreas}
+        id="top-patent-applications"
+        title={<>Top application areas across {data.name}'s AI patents</>}
+      />
+
+      <TableSection
+        columns={patentTableColumns}
+        css={styles.section}
+        data={patentIndustryAreas}
+        id="top-patent-industries"
+        title={<>Top industry areas across {data.name}'s AI patents</>}
+      />
+
+      <TrendsChart
+        css={styles.section}
+        {...aiSubfieldChartData}
+        id="ai-subfield-patents"
+        title={
+          <>
+            Trends in {data.name}'s patenting in
+            <Dropdown
+              inputLabel="patent subfield"
+              options={aiSubfieldOptions}
+              selected={aiSubfield}
+              setSelected={setAiSubfield}
+              showLabel={false}
+            />
+          </>
+        }
+      />
     </>
   );
 };

--- a/web/gui-v2/src/components/DetailViewPatents.jsx
+++ b/web/gui-v2/src/components/DetailViewPatents.jsx
@@ -55,18 +55,22 @@ const DetailViewPatents = ({
 
   const statGridEntries = [
     {
+      key: "ai-patents",
       stat: <>#{commas(data.patents.ai_patents.rank)}</>,
       text: <>in PARAT for number of AI-related patents</>,
     },
     {
+      key: "ai-patent-growth",
       stat: <>NUM%</>,
       text: <>growth in {data.name}'s AI patenting ({yearSpanNdash})</>,
     },
     {
+      key: "ai-patent-applications",
       stat: <>NUM</>,
       text: <div>AI patent <strong>applications</strong> were filed by {data.name} ({yearSpanNdash})</div>,
     },
     {
+      key: "ai-focused-percent",
       stat: <>NUM%</>,
       text: <>of {data.name}'s total patenting was AI-focused</>,
     },

--- a/web/gui-v2/src/components/DetailViewPatents.jsx
+++ b/web/gui-v2/src/components/DetailViewPatents.jsx
@@ -8,6 +8,7 @@ import StatGrid from './StatGrid';
 import TableSection from './TableSection';
 import TextAndBigStat from './TextAndBigStat';
 import TrendsChart from './TrendsChart';
+import { patentMap } from '../static_data/table_columns';
 import { commas } from '../util';
 import { assemblePlotlyParams } from '../util/plotly-helpers';
 
@@ -18,6 +19,13 @@ const styles = {
 
     h3 {
       margin-bottom: 0.5rem;
+    }
+  `,
+  trendsDropdown: css`
+    .MuiInputBase-input.MuiSelect-select {
+      align-items: center;
+      display: flex;
+      justify-content: center;
     }
   `,
 };
@@ -38,6 +46,13 @@ const DetailViewPatents = ({
 }) => {
   const [aiSubfield, setAiSubfield] = useState("ai_patents");
 
+  const numYears = data.years.length;
+  const startIx = numYears - 7;
+  const endIx = numYears - 2;
+
+  const yearSpanNdash = <>{data.years[startIx]}&ndash;{data.years[endIx]}</>;
+  // const yearSpanAnd = <>{data.years[startIx]} and {data.years[endIx]}</>;
+
   const statGridEntries = [
     {
       stat: <>#{commas(data.patents.ai_patents.rank)}</>,
@@ -45,11 +60,11 @@ const DetailViewPatents = ({
     },
     {
       stat: <>NUM%</>,
-      text: <>growth in {data.name}'s AI patenting (YEAR-YEAR)</>,
+      text: <>growth in {data.name}'s AI patenting ({yearSpanNdash})</>,
     },
     {
       stat: <>NUM</>,
-      text: <div>AI patent <strong>applications</strong> were filed by {data.name} (YEAR_YEAR)</div>,
+      text: <div>AI patent <strong>applications</strong> were filed by {data.name} ({yearSpanNdash})</div>,
     },
     {
       stat: <>NUM%</>,
@@ -57,9 +72,6 @@ const DetailViewPatents = ({
     },
   ];
 
-  const numYears = data.years.length;
-  const startIx = numYears - 7;
-  const endIx = numYears - 2;
   const patentTableColumns = [
     { display_name: "Subfield", key: "subfield" },
     { display_name: "Patents granted", key: "patents" },
@@ -92,13 +104,8 @@ const DetailViewPatents = ({
     };
   });
 
-  const aiSubfieldOptions = [
-    { text: "AI (all subtopics)", val: "ai_patents" },
-    // NOTE: Disable the other subtopics for now since the keys aren't in the data.
-    // { text: "Computer vision", val: "cv_patents" },
-    // { text: "Natural language processing", val: "nlp_patents" },
-    // { text: "Robotics", val: "robotics_patents" },
-  ];
+  // Temporarily using just a generic slice of patents
+  const aiSubfieldOptions = patentSubkeys.slice(0, 10).map(k => ({ text: patentMap[k], val: k }));
 
   const aiSubfieldChartData = assemblePlotlyParams(
     "Trends in research....",
@@ -147,6 +154,7 @@ const DetailViewPatents = ({
           <>
             Trends in {data.name}'s patenting in
             <Dropdown
+              css={styles.trendsDropdown}
               inputLabel="patent subfield"
               options={aiSubfieldOptions}
               selected={aiSubfield}

--- a/web/gui-v2/src/components/DetailViewPublications.jsx
+++ b/web/gui-v2/src/components/DetailViewPublications.jsx
@@ -21,7 +21,7 @@ const styles = {
     max-width: 808px;
 
     h3 {
-      margin-bottom: 0.25rem;
+      margin-bottom: 0.5rem;
     }
   `,
 };

--- a/web/gui-v2/src/components/DetailViewPublications.jsx
+++ b/web/gui-v2/src/components/DetailViewPublications.jsx
@@ -1,15 +1,103 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { css } from '@emotion/react';
+
+import {
+  Dropdown,
+  Table,
+  breakpoints,
+} from '@eto/eto-ui-components';
 
 import Chart from './DetailViewChart';
 import HeaderWithLink from './HeaderWithLink';
-import StatBox from './StatBox';
-import StatWrapper from './StatWrapper';
+import SectionHeading from './SectionHeading';
+import { commas } from '../util';
 import { assemblePlotlyParams } from '../util/plotly-helpers';
 
 const styles = {
   noTopMargin: css`
     margin-top: 0;
+  `,
+  sectionMargin: css`
+    margin: 1rem auto;
+    max-width: 808px;
+  `,
+  sectionWithHeading: css`
+    margin-top: 2rem;
+    h3 {
+      margin-bottom: 0.25rem;
+    }
+  `,
+  aiResearch: css`
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin-top: 1rem;
+
+    ${breakpoints.tablet_regular} {
+      flex-direction: row;
+    }
+
+    big {
+      font-family: GTZirkonRegular;
+      font-size: 180%;
+      margin-left: 0.5rem;
+    }
+  `,
+  stats: css`
+    display: grid;
+    gap: 0.5rem;
+    grid-template-columns: minmax(0, 400px);
+    list-style: none;
+    margin: 1rem auto;
+    max-width: fit-content;
+    padding: 0;
+
+    ${breakpoints.tablet_regular} {
+      grid-template-columns: repeat(2, minmax(0, 400px));
+    }
+
+    & > li {
+      align-content: center;
+      border: 1px solid var(--bright-blue-light);
+      display: grid;
+      gap: 0.5rem;
+      grid-template-columns: 80px 1fr;
+      max-width: 400px;
+      padding: 0.5rem;
+
+      & > div {
+        align-items: center;
+        display: flex;
+
+        &:first-of-type {
+          font-size: 150%;
+          justify-content: right;
+        }
+      }
+    }
+  `,
+  topResearchTopics: css`
+    margin: 1rem auto;
+    max-width: 808px;
+  `,
+  topResearchTopicsTable: css`
+    max-width: 808px;
+  `,
+  aiSubfieldChart: css`
+    h3 {
+      align-items: center;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      margin: 0 auto;
+      width: fit-content;
+
+      .dropdown .MuiFormControl-root {
+        margin: 0;
+        margin-left: 0.5rem;
+      }
+    }
   `,
 };
 
@@ -26,21 +114,58 @@ const chartLayoutChanges = {
 const DetailViewPublications = ({
   data,
 }) => {
-  const allVsAi = assemblePlotlyParams(
-    "All publications vs topics over time",
+  const [aiSubfield, setAiSubfield] = useState("ai_publications");
+
+  const averageCitations = Math.round(10 * data.articles.citation_counts.total / data.articles.all_publications.total) / 10;
+
+  const topAiResearchTopicsColumns = [
+    { display_name: "Subfield", key: "subfield" },
+    { display_name: "Articles", key: "articles" },
+    { display_name: "Citations per article", key: "citations" },
+    { display_name: <>Growth (YEAR&ndash;YEAR)</>, key: "growth" },
+  ];
+  const topAiResearchTopics = [
+    {
+      subfield: "Computer vision",
+      articles: data.articles.cv_pubs.total,
+      citations: "???",
+      growth: "???",
+    },
+    {
+      subfield: "Natural language processing",
+      articles: data.articles.nlp_pubs.total,
+      citations: "???",
+      growth: "???",
+    },
+    {
+      subfield: "Robotics",
+      articles: data.articles.robotics_pubs.total,
+      citations: "???",
+      growth: "???",
+    },
+  ];
+
+  const aiSubfieldOptions = [
+    { text: "AI (all subtopics)", val: "ai_publications" },
+    { text: "Computer vision", val: "cv_pubs" },
+    { text: "Natural language processing", val: "nlp_pubs" },
+    { text: "Robotics", val: "robotics_pubs" },
+  ];
+
+  const aiSubfieldChartData = assemblePlotlyParams(
+    "Trends in research....",
     data.years,
     [
-      ["All publications", data.articles.all_publications.counts],
-      ["AI publications", data.articles.ai_publications.counts],
-      ["CV publications", data.articles.cv_pubs.counts],
-      ["NLP publications", data.articles.nlp_pubs.counts],
-      ["Robotics publications", data.articles.robotics_pubs.counts],
+      [
+        aiSubfieldOptions.find(e => e.val === aiSubfield)?.text,
+        data.articles[aiSubfield].counts
+      ],
     ],
     chartLayoutChanges,
   );
 
   const topConfs = assemblePlotlyParams(
-    "AI top conference publications",
+    <>{data.name}'s top AI conference publications</>,
     data.years,
     [
       ["AI top conference publications", data.articles.ai_pubs_top_conf.counts],
@@ -48,43 +173,75 @@ const DetailViewPublications = ({
     chartLayoutChanges,
   );
 
-  const averageCitations = Math.round(10 * data.articles.citation_counts.total / data.articles.all_publications.total) / 10;
-
   return (
     <>
       <HeaderWithLink css={styles.noTopMargin} title="Publications" />
 
-      <p>
-        Radio telescope light years extraplanetary the sky calls to us billions
-        upon billions cosmic ocean. The only home we've ever known tesseract
-        tesseract dream of the mind's eye Apollonius of Perga take root and
-        flourish? Euclid realm of the galaxies inconspicuous motes of rock and
-        gas great turbulent clouds decipherment network of wormholes.
-      </p>
-      <Chart {...allVsAi} />
-      <p>
-        The carbon in our apple pies circumnavigated venture worldlets Orion's
-        sword network of wormholes. Permanence of the stars another world
-        preserve and cherish that pale blue dot kindling the energy hidden in
-        matter muse about vastness is bearable only through love. Hearts of the
-        stars realm of the galaxies birth dispassionate extraterrestrial
-        observer vastness is bearable only through love not a sunrise but a
-        galaxyrise. Encyclopaedia galactica rich in heavy atoms made in the
-        interiors of collapsing stars descended from astronomers the only home
-        we've ever known.
-      </p>
-      <Chart {...topConfs} />
-      <p>
-        Brain is the seed of intelligence a mote of dust suspended in a sunbeam
-        light years ship of the imagination cosmic ocean muse about. Finite but
-        unbounded a still more glorious dawn awaits permanence of the stars
-        vanquish the impossible bits of moving fluff corpus callosum. Vanquish
-        the impossible preserve and cherish that pale blue dot citizens of
-        distant epochs inconspicuous motes of rock and gas.
-      </p>
-      <StatWrapper>
-        <StatBox label="Average citations per article" value={averageCitations} />
-      </StatWrapper>
+      <div css={[styles.aiResearch]}>
+        Between {data.years[0]} and {data.years[data.years.length-1]}, {data.name} researchers released
+        <big>{data.articles.ai_publications.total} AI research articles</big>
+      </div>
+
+      <ul css={[styles.sectionMargin, styles.stats]}>
+        <li>
+          <div>#{data.articles.ai_publications.rank}</div>
+          <div>in PARAT for number of AI research articles</div>
+        </li>
+        <li>
+          <div>{averageCitations}</div>
+          <div>citations per article on average (#RANK in PARAT, #RANK in the S&P 500)</div>
+        </li>
+        <li>
+          <div>NUMBER</div>
+          <div>highly-cited articles (#RANK in PARAT, #RANK in the S&P 500)</div>
+        </li>
+        <li>
+          <div>NUM%</div>
+          <div>growth in {data.name}'s public AI research (YEAR-YEAR)</div>
+        </li>
+        <li>
+          <div>{commas(data.articles.ai_pubs_top_conf.total)}</div>
+          <div>articles at top AI conferences (#{data.articles.ai_pubs_top_conf.rank} in PARAT, #RANK in the S&P 500)</div>
+        </li>
+        <li>
+          <div>NUM%</div>
+          <div>of {data.name}'s total public research was AI-focused</div>
+        </li>
+      </ul>
+
+      <div css={[styles.sectionMargin, styles.sectionWithHeading, styles.topResearchTopics]}>
+        <SectionHeading id="top-research-topics">
+          {data.name}'s top AI research topics
+        </SectionHeading>
+        <Table
+          columns={topAiResearchTopicsColumns}
+          css={styles.topResearchTopicsTable}
+          data={topAiResearchTopics}
+        />
+      </div>
+
+      <div css={[styles.sectionMargin, styles.sectionWithHeading, styles.aiSubfieldChart]}>
+        <Chart
+          {...aiSubfieldChartData}
+          id="ai-subfield-research"
+          title={
+            <>
+              Trends in {data.name}'s research in
+              <Dropdown
+                inputLabel="AI subfield"
+                options={aiSubfieldOptions}
+                selected={aiSubfield}
+                setSelected={setAiSubfield}
+                showLabel={false}
+              />
+            </>
+          }
+        />
+      </div>
+
+      <div css={[styles.sectionMargin, styles.sectionWithHeading]}>
+        <Chart {...topConfs} id="ai-top-conference-pubs" />
+      </div>
     </>
   );
 };

--- a/web/gui-v2/src/components/DetailViewPublications.jsx
+++ b/web/gui-v2/src/components/DetailViewPublications.jsx
@@ -61,26 +61,32 @@ const DetailViewPublications = ({
 
   const statGridEntries = [
     {
+      key: "ai-papers",
       stat: <>#{data.articles.ai_publications.rank}</>,
       text: <>in PARAT for number of AI research articles</>,
     },
     {
+      key: "average-citations",
       stat: <>{averageCitations}</>,
       text: <>citations per article on average (#RANK in PARAT, #RANK in the S&P 500)</>,
     },
     {
+      key: "highly-cited",
       stat: <>NUMBER</>,
       text: <>highly-cited articles (#RANK in PARAT, #RANK in the S&P 500)</>,
     },
     {
+      key: "ai-research-growth",
       stat: <>NUM%</>,
       text: <>growth in {data.name}'s public AI research ({yearSpanNdash})</>,
     },
     {
+      key: "ai-top-conf",
       stat: <>{commas(data.articles.ai_pubs_top_conf.total)}</>,
       text: <>articles at top AI conferences (#{data.articles.ai_pubs_top_conf.rank} in PARAT, #RANK in the S&P 500)</>,
     },
     {
+      key: "ai-research-percent",
       stat: <>{aiResearchPercent}%</>,
       text: <>of {data.name}'s total public research was AI-focused</>,
     },

--- a/web/gui-v2/src/components/DetailViewPublications.jsx
+++ b/web/gui-v2/src/components/DetailViewPublications.jsx
@@ -1,15 +1,14 @@
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
 
-import {
-  Dropdown,
-  Table,
-  breakpoints,
-} from '@eto/eto-ui-components';
+import { Dropdown } from '@eto/eto-ui-components';
 
 import Chart from './DetailViewChart';
 import HeaderWithLink from './HeaderWithLink';
-import SectionHeading from './SectionHeading';
+import StatGrid from './StatGrid';
+import TableSection from './TableSection';
+import TextAndBigStat from './TextAndBigStat';
+import TrendsChart from './TrendsChart';
 import { commas } from '../util';
 import { assemblePlotlyParams } from '../util/plotly-helpers';
 
@@ -17,86 +16,12 @@ const styles = {
   noTopMargin: css`
     margin-top: 0;
   `,
-  sectionMargin: css`
-    margin: 1rem auto;
+  section: css`
+    margin: 2rem auto 1rem;
     max-width: 808px;
-  `,
-  sectionWithHeading: css`
-    margin-top: 2rem;
+
     h3 {
       margin-bottom: 0.25rem;
-    }
-  `,
-  aiResearch: css`
-    align-items: center;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    margin-top: 1rem;
-
-    ${breakpoints.tablet_regular} {
-      flex-direction: row;
-    }
-
-    big {
-      font-family: GTZirkonRegular;
-      font-size: 180%;
-      margin-left: 0.5rem;
-    }
-  `,
-  stats: css`
-    display: grid;
-    gap: 0.5rem;
-    grid-template-columns: minmax(0, 400px);
-    list-style: none;
-    margin: 1rem auto;
-    max-width: fit-content;
-    padding: 0;
-
-    ${breakpoints.tablet_regular} {
-      grid-template-columns: repeat(2, minmax(0, 400px));
-    }
-
-    & > li {
-      align-content: center;
-      border: 1px solid var(--bright-blue-light);
-      display: grid;
-      gap: 0.5rem;
-      grid-template-columns: 80px 1fr;
-      max-width: 400px;
-      padding: 0.5rem;
-
-      & > div {
-        align-items: center;
-        display: flex;
-
-        &:first-of-type {
-          font-size: 150%;
-          justify-content: right;
-        }
-      }
-    }
-  `,
-  topResearchTopics: css`
-    margin: 1rem auto;
-    max-width: 808px;
-  `,
-  topResearchTopicsTable: css`
-    max-width: 808px;
-  `,
-  aiSubfieldChart: css`
-    h3 {
-      align-items: center;
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      margin: 0 auto;
-      width: fit-content;
-
-      .dropdown .MuiFormControl-root {
-        margin: 0;
-        margin-left: 0.5rem;
-      }
     }
   `,
 };
@@ -117,6 +42,33 @@ const DetailViewPublications = ({
   const [aiSubfield, setAiSubfield] = useState("ai_publications");
 
   const averageCitations = Math.round(10 * data.articles.citation_counts.total / data.articles.all_publications.total) / 10;
+
+  const statGridEntries = [
+    {
+      stat: <>#{data.articles.ai_publications.rank}</>,
+      text: <>in PARAT for number of AI research articles</>,
+    },
+    {
+      stat: <>{averageCitations}</>,
+      text: <>citations per article on average (#RANK in PARAT, #RANK in the S&P 500)</>,
+    },
+    {
+      stat: <>NUMBER</>,
+      text: <>highly-cited articles (#RANK in PARAT, #RANK in the S&P 500)</>,
+    },
+    {
+      stat: <>NUM%</>,
+      text: <>growth in {data.name}'s public AI research (YEAR-YEAR)</>,
+    },
+    {
+      stat: <>{commas(data.articles.ai_pubs_top_conf.total)}</>,
+      text: <>articles at top AI conferences (#{data.articles.ai_pubs_top_conf.rank} in PARAT, #RANK in the S&P 500)</>,
+    },
+    {
+      stat: <>NUM%</>,
+      text: <>of {data.name}'s total public research was AI-focused</>,
+    },
+  ];
 
   const topAiResearchTopicsColumns = [
     { display_name: "Subfield", key: "subfield" },
@@ -177,69 +129,40 @@ const DetailViewPublications = ({
     <>
       <HeaderWithLink css={styles.noTopMargin} title="Publications" />
 
-      <div css={[styles.aiResearch]}>
-        Between {data.years[0]} and {data.years[data.years.length-1]}, {data.name} researchers released
-        <big>{data.articles.ai_publications.total} AI research articles</big>
-      </div>
+      <TextAndBigStat
+        smallText={<>Between {data.years[0]} and {data.years[data.years.length-1]}, {data.name} researchers released</>}
+        bigText={<>{commas(data.articles.ai_publications.total)} AI research articles</>}
+      />
 
-      <ul css={[styles.sectionMargin, styles.stats]}>
-        <li>
-          <div>#{data.articles.ai_publications.rank}</div>
-          <div>in PARAT for number of AI research articles</div>
-        </li>
-        <li>
-          <div>{averageCitations}</div>
-          <div>citations per article on average (#RANK in PARAT, #RANK in the S&P 500)</div>
-        </li>
-        <li>
-          <div>NUMBER</div>
-          <div>highly-cited articles (#RANK in PARAT, #RANK in the S&P 500)</div>
-        </li>
-        <li>
-          <div>NUM%</div>
-          <div>growth in {data.name}'s public AI research (YEAR-YEAR)</div>
-        </li>
-        <li>
-          <div>{commas(data.articles.ai_pubs_top_conf.total)}</div>
-          <div>articles at top AI conferences (#{data.articles.ai_pubs_top_conf.rank} in PARAT, #RANK in the S&P 500)</div>
-        </li>
-        <li>
-          <div>NUM%</div>
-          <div>of {data.name}'s total public research was AI-focused</div>
-        </li>
-      </ul>
+      <StatGrid css={styles.sectionMargin} entries={statGridEntries} />
 
-      <div css={[styles.sectionMargin, styles.sectionWithHeading, styles.topResearchTopics]}>
-        <SectionHeading id="top-research-topics">
-          {data.name}'s top AI research topics
-        </SectionHeading>
-        <Table
-          columns={topAiResearchTopicsColumns}
-          css={styles.topResearchTopicsTable}
-          data={topAiResearchTopics}
-        />
-      </div>
+      <TableSection
+        columns={topAiResearchTopicsColumns}
+        css={styles.section}
+        data={topAiResearchTopics}
+        id="top-research-topics"
+        title={<>{data.name}'s top AI research topics</>}
+      />
 
-      <div css={[styles.sectionMargin, styles.sectionWithHeading, styles.aiSubfieldChart]}>
-        <Chart
-          {...aiSubfieldChartData}
-          id="ai-subfield-research"
-          title={
-            <>
-              Trends in {data.name}'s research in
-              <Dropdown
-                inputLabel="AI subfield"
-                options={aiSubfieldOptions}
-                selected={aiSubfield}
-                setSelected={setAiSubfield}
-                showLabel={false}
-              />
-            </>
-          }
-        />
-      </div>
+      <TrendsChart
+        css={styles.section}
+        {...aiSubfieldChartData}
+        id="ai-subfield-research"
+        title={
+          <>
+            Trends in {data.name}'s research in
+            <Dropdown
+              inputLabel="AI subfield"
+              options={aiSubfieldOptions}
+              selected={aiSubfield}
+              setSelected={setAiSubfield}
+              showLabel={false}
+            />
+          </>
+        }
+      />
 
-      <div css={[styles.sectionMargin, styles.sectionWithHeading]}>
+      <div css={styles.section}>
         <Chart {...topConfs} id="ai-top-conference-pubs" />
       </div>
     </>

--- a/web/gui-v2/src/components/DetailViewWorkforce.jsx
+++ b/web/gui-v2/src/components/DetailViewWorkforce.jsx
@@ -4,27 +4,34 @@ import HeaderWithLink from './HeaderWithLink';
 import StatBox from './StatBox';
 import StatWrapper from './StatWrapper';
 
+const DetailViewWorkforce = ({
+  data,
+}) => {
+  const yearSpanText = <>{data.years[0]} to {data.years[data.years.length-1]}</>;
 
-const DetailViewWorkforce = () => {
+  const otherMetricsWorkforceKeys = ['ai_jobs', 'tt1_jobs'];
+
   return (
     <>
       <HeaderWithLink title="Workforce" />
 
       <StatWrapper>
-        <StatBox label="tt1 jobs" value="1536" />
-        <StatBox label="AI jobs" value="3456" />
+        { otherMetricsWorkforceKeys.map((key) => (
+          <StatBox
+            description={
+              <>
+                From {yearSpanText}, {data.name} here is some explanatory text
+                describing how they had NUMBER jobs of the specified type
+                (#{data.other_metrics[key].rank} rank in PARAT
+                {data.in_sandp_500 && <>, #NUMBER in the S&P500</>})
+              </>
+            }
+            key={key}
+            label={data.other_metrics[key].name}
+            value={data.other_metrics[key].total}
+          />
+        ))}
       </StatWrapper>
-      <p>
-        The carbon in our apple pies circumnavigated venture worldlets Orion's
-        sword network of wormholes. Permanence of the stars another world
-        preserve and cherish that pale blue dot kindling the energy hidden in
-        matter muse about vastness is bearable only through love. Hearts of the
-        stars realm of the galaxies birth dispassionate extraterrestrial
-        observer vastness is bearable only through love not a sunrise but a
-        galaxyrise. Encyclopaedia galactica rich in heavy atoms made in the
-        interiors of collapsing stars descended from astronomers the only home
-        we've ever known.
-      </p>
     </>
   );
 };

--- a/web/gui-v2/src/components/SectionHeading.jsx
+++ b/web/gui-v2/src/components/SectionHeading.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { css } from '@emotion/react';
+
+const styles = {
+  chartTitle: css`
+    font-family: GTZirkonMedium;
+    font-size: 24px;
+    margin-bottom: 0;
+    text-align: center;
+  `,
+};
+
+const SectionHeading = ({ children, id }) => {
+  return (
+    <h3 css={styles.chartTitle} id={id}>
+      {children}
+    </h3>
+  );
+};
+
+export default SectionHeading;

--- a/web/gui-v2/src/components/StatBox.jsx
+++ b/web/gui-v2/src/components/StatBox.jsx
@@ -4,6 +4,11 @@ import { css } from '@emotion/react';
 import { commas } from '../util';
 
 const styles = {
+  outerWrapper: css`
+    column-gap: 2rem;
+    display: grid;
+    grid-template-columns: 240px 1fr;
+  `,
   statbox: css`
     align-items: center;
     background-color: var(--bright-blue-lighter);
@@ -11,7 +16,7 @@ const styles = {
     color: var(--bright-blue);
     display: flex;
     flex-direction: column;
-    padding: 1rem 3rem;
+    padding: 1rem 1rem;
   `,
   label: css`
     font-size: 1.25rem;
@@ -19,17 +24,25 @@ const styles = {
   value: css`
     font-size: 2.5rem;
   `,
+  description: css`
+    align-items: center;
+    display: flex;
+  `,
 };
 
 const StatBox = ({
+  description,
   label,
   value,
 }) => {
 
   return (
-    <div css={styles.statbox}>
-      <div css={styles.value}>{commas(value)}</div>
-      <div css={styles.label}>{label}</div>
+    <div css={styles.outerWrapper}>
+      <div css={styles.statbox}>
+        <div css={styles.value}>{commas(value)}</div>
+        <div css={styles.label}>{label}</div>
+      </div>
+      <div css={styles.description}>{description}</div>
     </div>
   );
 };

--- a/web/gui-v2/src/components/StatGrid.jsx
+++ b/web/gui-v2/src/components/StatGrid.jsx
@@ -62,7 +62,7 @@ const StatGrid = ({
       {
         entries.map((entry) => {
           return (
-            <li key={entry.text}>
+            <li key={entry.key ?? entry.text}>
               <div>{entry.stat}</div>
               <div>{entry.text}</div>
             </li>

--- a/web/gui-v2/src/components/StatGrid.jsx
+++ b/web/gui-v2/src/components/StatGrid.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { css } from '@emotion/react';
+
+import { breakpoints } from '@eto/eto-ui-components';
+
+const styles = {
+  stats: css`
+    display: grid;
+    gap: 0.5rem;
+    grid-template-columns: minmax(0, 400px);
+    list-style: none;
+    margin: 1rem auto;
+    max-width: fit-content;
+    padding: 0;
+
+    ${breakpoints.tablet_regular} {
+      grid-template-columns: repeat(2, minmax(0, 400px));
+    }
+
+    & > li {
+      align-content: center;
+      border: 1px solid var(--bright-blue-light);
+      display: grid;
+      gap: 0.5rem;
+      grid-template-columns: 80px 1fr;
+      max-width: 400px;
+      padding: 0.5rem;
+
+      & > div {
+        align-items: center;
+        display: flex;
+
+        &:first-of-type {
+          font-size: 150%;
+          justify-content: right;
+        }
+      }
+    }
+  `,
+};
+
+
+/**
+ * A responsive grid of boxes, each presenting a statistic and an explanation.
+ *
+ * @param {object} props
+ * @param {Array<{stat: ReactNode, text: ReactNode}>} props.entries
+ * @returns {JSX.Element}
+ */
+const StatGrid = ({
+  className: appliedClassName,
+  css: appliedCss,
+  entries,
+  id: appliedId,
+}) => {
+  return (
+    <ul
+      className={appliedClassName}
+      css={[styles.stats, appliedCss]}
+      id={appliedId}
+    >
+      {
+        entries.map((entry) => {
+          return (
+            <li key={entry.text}>
+              <div>{entry.stat}</div>
+              <div>{entry.text}</div>
+            </li>
+          );
+        })
+      }
+    </ul>
+  );
+};
+
+export default StatGrid;

--- a/web/gui-v2/src/components/StatGrid.jsx
+++ b/web/gui-v2/src/components/StatGrid.jsx
@@ -19,9 +19,8 @@ const styles = {
 
     & > li {
       align-content: center;
-      border: 1px solid var(--bright-blue-light);
       display: grid;
-      gap: 0.5rem;
+      gap: 1rem;
       grid-template-columns: 80px 1fr;
       max-width: 400px;
       padding: 0.5rem;
@@ -31,7 +30,8 @@ const styles = {
         display: flex;
 
         &:first-of-type {
-          font-size: 150%;
+          font-family: GTZirkonMedium;
+          font-size: 200%;
           justify-content: right;
         }
       }

--- a/web/gui-v2/src/components/StatWrapper.jsx
+++ b/web/gui-v2/src/components/StatWrapper.jsx
@@ -4,6 +4,8 @@ import { css } from '@emotion/react';
 const styles = {
   statWrapper: css`
     display: flex;
+    flex-direction: column;
+    gap: 2rem;
     justify-content: space-around;
     margin: 1rem auto;
     max-width: 720px;

--- a/web/gui-v2/src/components/StatWrapper.jsx
+++ b/web/gui-v2/src/components/StatWrapper.jsx
@@ -7,7 +7,7 @@ const styles = {
     flex-direction: column;
     gap: 2rem;
     justify-content: space-around;
-    margin: 1rem auto;
+    margin: 2rem auto;
     max-width: 720px;
   `,
 };

--- a/web/gui-v2/src/components/TableSection.jsx
+++ b/web/gui-v2/src/components/TableSection.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { css } from '@emotion/react';
+
+import { Table } from '@eto/eto-ui-components';
+
+import SectionHeading from './SectionHeading';
+
+const styles = {
+  tableWrapper: css`
+    margin: 1rem auto;
+    max-width: 808px;
+  `,
+  table: css`
+    max-width: 808px;
+  `,
+};
+
+const TableSection = ({
+  className: appliedClassName,
+  columns,
+  css: appliedCss,
+  data,
+  id: appliedId,
+  title,
+}) => {
+  return (
+    <div
+      className={appliedClassName}
+      css={[styles.tableWrapper, appliedCss]}
+    >
+      <SectionHeading id={appliedId}>
+        {title}
+      </SectionHeading>
+      <Table
+        columns={columns}
+        css={styles.table}
+        data={data}
+      />
+    </div>
+  );
+};
+
+export default TableSection;

--- a/web/gui-v2/src/components/TextAndBigStat.jsx
+++ b/web/gui-v2/src/components/TextAndBigStat.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { css } from '@emotion/react';
+
+import { breakpoints } from '@eto/eto-ui-components';
+
+const styles = css`
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin-top: 1rem;
+
+  ${breakpoints.tablet_regular} {
+    flex-direction: row;
+  }
+
+  big {
+    font-family: GTZirkonRegular;
+    font-size: 180%;
+    margin-left: 0.5rem;
+  }
+`;
+
+const TextAndBigStat = ({
+  bigText,
+  className: appliedClassName,
+  css: appliedCss,
+  id: appliedId,
+  smallText,
+}) => {
+  return (
+    <div
+      className={appliedClassName}
+      css={[styles, appliedCss]}
+      id={appliedId}
+    >
+      {smallText}
+      <big>{bigText}</big>
+    </div>
+  );
+};
+
+export default TextAndBigStat;

--- a/web/gui-v2/src/components/TextAndBigStat.jsx
+++ b/web/gui-v2/src/components/TextAndBigStat.jsx
@@ -1,23 +1,22 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
-import { breakpoints } from '@eto/eto-ui-components';
-
 const styles = css`
   align-items: center;
+  column-gap: 0.5rem;
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   justify-content: center;
   margin-top: 1rem;
 
-  ${breakpoints.tablet_regular} {
-    flex-direction: row;
+  span {
+    font-size: 120%;
+    text-align: center;
   }
 
   big {
     font-family: GTZirkonRegular;
     font-size: 180%;
-    margin-left: 0.5rem;
   }
 `;
 
@@ -34,7 +33,7 @@ const TextAndBigStat = ({
       css={[styles, appliedCss]}
       id={appliedId}
     >
-      {smallText}
+      <span>{smallText}</span>
       <big>{bigText}</big>
     </div>
   );

--- a/web/gui-v2/src/components/TrendsChart.jsx
+++ b/web/gui-v2/src/components/TrendsChart.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { css } from '@emotion/react';
+
+import Chart from './DetailViewChart';
+
+const styles = {
+  chartWrapper: css`
+    h3 {
+      align-items: center;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      margin: 0 auto;
+      width: fit-content;
+
+      .dropdown .MuiFormControl-root {
+        margin: 0;
+        margin-left: 0.5rem;
+      }
+    }
+  `,
+};
+
+const TrendsChart = ({
+  className: appliedClassName,
+  css: appliedCss,
+  id: appliedId,
+  title,
+  ...otherProps
+}) => {
+  return (
+    <div
+      className={appliedClassName}
+      css={[styles.sectionMargin, styles.sectionWithHeading, styles.chartWrapper, appliedCss]}
+      id={appliedId}
+    >
+      <Chart
+        {...otherProps}
+        id={appliedId}
+        title={title}
+      />
+    </div>
+  );
+};
+
+export default TrendsChart;

--- a/web/gui-v2/src/components/TwoColumnTable.jsx
+++ b/web/gui-v2/src/components/TwoColumnTable.jsx
@@ -56,7 +56,7 @@ const TwoColumnTable = ({
     >
       <tbody>
         {data.map((row) => (
-          <tr>
+          <tr key={row.title}>
             <th scope="row">{row.title}</th>
             <td>{row.value ?? <span css={styles.notFound}>None found</span>}</td>
           </tr>

--- a/web/gui-v2/src/static_data/table_columns.js
+++ b/web/gui-v2/src/static_data/table_columns.js
@@ -54,7 +54,7 @@ const generateSliderColDef = (dataKey, dataSubkey) => {
   }
 };
 
-export default [
+const columnDefinitions = [
   {
     title: "Company",
     key: "name",
@@ -219,3 +219,14 @@ export default [
     ...generateSliderColDef("other_metrics", "tt1_jobs"),
   },
 ];
+export default columnDefinitions;
+
+export const articleMap = Object.fromEntries(columnDefinitions
+  .filter(e => e.dataKey === 'articles')
+  .map(e => ([e.dataSubkey, e.title]))
+);
+
+export const patentMap = Object.fromEntries(columnDefinitions
+  .filter(e => e.dataKey === 'patents')
+  .map(e => ([e.dataSubkey, e.title]))
+);


### PR DESCRIPTION
Update the layout of the company detail page based on Zach's mockups (except for the intro section, which is handled by #129)

### Styling note
~~The current styling in the "StatGrid" sections is temporary - the light blue border was initially just to get a sense of what elements were where during development.  We can discuss final styles during the review process.~~  Outline removed per Zach

![parat-statgrid-section](https://github.com/georgetown-cset/parat/assets/22353962/f6c5cd5c-a092-4c38-ba39-811bcd0569d0)

### Related issues:
* Closes #88
* Unsure about #89
* Partial(?) #86
* Closes #85
* Closes #87
* Closes #122

### Pending needs
* [ ] Some data are included in their final spots already, while others still have placeholder text
* [ ] Need some way of identifying the appropriate data for the "top AI research" table
* [ ] Need clarification of what specific data keys should be used for the "application areas" and "industry areas" tables - in the meantime I'm just taking the first few values from the `patents` object
* [ ] AI subfields currently aren't in the patent data, so the patent chart dropdown only has `ai_patents` enabled
