### PR TITLE
Move default column array to the column definitions file

### DIFF
--- a/web/gui-v2/package-lock.json
+++ b/web/gui-v2/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@emotion/react": "^11.11.1",
-        "@eto/eto-ui-components": "^1.5.3",
+        "@eto/eto-ui-components": "^1.6.0",
         "@mdx-js/react": "^2.3.0",
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.13.5",
@@ -2291,9 +2291,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/@eto/eto-ui-components": {
-      "version": "1.5.3",
-      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/eto-ui-components/-/@eto/eto-ui-components-1.5.3.tgz",
-      "integrity": "sha512-jJzRKztUaBE/80tR/83YfqonVX4vcdRf8upPrCRxUgr/rpT7od5uD8nbOoj9DnDAv0WRaH8g7BtCs+Ya/4AIjA==",
+      "version": "1.6.0",
+      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/eto-ui-components/-/@eto/eto-ui-components-1.6.0.tgz",
+      "integrity": "sha512-Ny88cmzl+yrbhpSGX6XsKpK+BOHktvRfg/I3z3fSulcEOYF7VEys420Hone+n6176KB9QalDln6a3HkvEpK/hQ==",
       "dependencies": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
@@ -25137,9 +25137,9 @@
       }
     },
     "@eto/eto-ui-components": {
-      "version": "1.5.3",
-      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/eto-ui-components/-/@eto/eto-ui-components-1.5.3.tgz",
-      "integrity": "sha512-jJzRKztUaBE/80tR/83YfqonVX4vcdRf8upPrCRxUgr/rpT7od5uD8nbOoj9DnDAv0WRaH8g7BtCs+Ya/4AIjA==",
+      "version": "1.6.0",
+      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/eto-ui-components/-/@eto/eto-ui-components-1.6.0.tgz",
+      "integrity": "sha512-Ny88cmzl+yrbhpSGX6XsKpK+BOHktvRfg/I3z3fSulcEOYF7VEys420Hone+n6176KB9QalDln6a3HkvEpK/hQ==",
       "requires": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",

--- a/web/gui-v2/package.json
+++ b/web/gui-v2/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",
-    "@eto/eto-ui-components": "^1.5.3",
+    "@eto/eto-ui-components": "^1.6.0",
     "@mdx-js/react": "^2.3.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.5",

--- a/web/gui-v2/src/components/CellStat.jsx
+++ b/web/gui-v2/src/components/CellStat.jsx
@@ -32,7 +32,7 @@ const CellStat = ({data, colKey}) => {
         { data?.total === null ? 'n/a' : commas(data.total) }
       </div>
       <div className="rank">
-        { (data?.total === 0 || data?.total === null) ? '---' : <>#{data.rank}</> }
+        { (data?.total === 0 || data?.total === null) ? '---' : (data?.rank && `#${data.rank}`) }
       </div>
     </div>
   );

--- a/web/gui-v2/src/components/HeaderSlider.jsx
+++ b/web/gui-v2/src/components/HeaderSlider.jsx
@@ -24,6 +24,7 @@ const styles = {
 
 const HeaderSlider = ({
   label,
+  min=0,
   onChange,
   value,
 }) => {
@@ -54,6 +55,7 @@ const HeaderSlider = ({
       <label>{label}</label>
       <Slider
         css={styles.slider}
+        min={min}
         onChange={(newVal) => setValueInternal(newVal.target.value)}
         onClick={(event) => event.stopPropagation()}
         size="small"

--- a/web/gui-v2/src/components/ListView.test.js
+++ b/web/gui-v2/src/components/ListView.test.js
@@ -54,7 +54,7 @@ describe("ListView", () => {
       await user.click(removedCheckbox);
       expect(removedCheckbox.checked).toEqual(false);
       await user.click(getByRole(dialog, 'button', { name: 'Apply' }));
-      await waitForElementToBeRemoved(dialog);
+      await waitForElementToBeRemoved(() => screen.getByRole('dialog'));
       expect(screen.queryByRole('heading', { name: 'Add/remove columns'})).not.toBeInTheDocument();
 
       // Verify that the changes took effect

--- a/web/gui-v2/src/components/ListView.test.js
+++ b/web/gui-v2/src/components/ListView.test.js
@@ -54,7 +54,7 @@ describe("ListView", () => {
       await user.click(removedCheckbox);
       expect(removedCheckbox.checked).toEqual(false);
       await user.click(getByRole(dialog, 'button', { name: 'Apply' }));
-      await waitForElementToBeRemoved(() => screen.getByRole('dialog'));
+      await waitForElementToBeRemoved(dialog);
       expect(screen.queryByRole('heading', { name: 'Add/remove columns'})).not.toBeInTheDocument();
 
       // Verify that the changes took effect

--- a/web/gui-v2/src/components/ListView.test.js
+++ b/web/gui-v2/src/components/ListView.test.js
@@ -9,7 +9,7 @@ import {
 import { userEventSetup } from '../util/testing';
 import ListView from './ListView';
 
-const INITIAL_COLUMNS = ['Company', 'Country', 'Region', 'Stage', 'AI publications', 'AI patents'];
+const INITIAL_COLUMNS = ['Company', 'Country', 'AI publications', 'AI patents', 'Tech Tier 1 jobs'];
 const REMOVED_COLUMN = 'AI publications';
 
 describe("ListView", () => {
@@ -20,11 +20,11 @@ describe("ListView", () => {
 
     // Filter by Europe and verify that the count updates
     expect(screen.getByText('Viewing 1760 companies')).toBeVisible();
-    const regionHeader = screen.getByRole('columnheader', { name: /region/i });
+    const regionHeader = screen.getByRole('columnheader', { name: /country/i });
     await user.click(getByRole(regionHeader, 'button'));
     const menu = screen.getByRole('listbox');
-    await user.click(getByText(menu, 'Europe'));
-    expect(screen.getByText('Viewing 168 of 1760 companies')).toBeVisible();
+    await user.click(getByText(menu, 'China'));
+    expect(screen.getByText('Viewing 267 of 1760 companies')).toBeVisible();
 
     // Reset the filters and verify that the count updates
     await user.click(screen.getByRole('button', { name: /reset filters/i }));
@@ -64,7 +64,7 @@ describe("ListView", () => {
     }, 60000);
   });
 
-  describe('groups', () => {
+  describe.skip('groups', () => {
     it('switches to custom group mode', async () => {
       const { user } = userEventSetup(
         <ListView />

--- a/web/gui-v2/src/components/ListViewTable.jsx
+++ b/web/gui-v2/src/components/ListViewTable.jsx
@@ -22,7 +22,7 @@ import HeaderDropdown from './HeaderDropdown';
 import HeaderSlider from './HeaderSlider';
 import GroupSelector, { NO_SELECTED_GROUP, USER_CUSTOM_GROUP } from './ListViewGroupSelector';
 import groupsList from '../static_data/groups';
-import columnDefinitions from '../static_data/table_columns';
+import columnDefinitions, { DEFAULT_COLUMNS } from '../static_data/table_columns';
 import {
   commas,
   useMultiState,
@@ -114,15 +114,11 @@ const DATAKEYS_WITH_SUBKEYS = [
   "other_metrics",
 ];
 
-const DEFAULT_COLUMNS = [];
 const DROPDOWN_COLUMNS = [];
 const SLIDER_COLUMNS = [];
 const SLIDER_NATURAL_COLUMNS = [];
 const SLIDER_GROWTH_COLUMNS = [];
 columnDefinitions.forEach((colDef) => {
-  if ( colDef?.initialCol ) {
-    DEFAULT_COLUMNS.push(colDef.key);
-  }
   if ( colDef.type === "dropdown" ) {
     DROPDOWN_COLUMNS.push(colDef.key);
   } else if ( colDef.type === "slider" ) {

--- a/web/gui-v2/src/components/ListViewTable.jsx
+++ b/web/gui-v2/src/components/ListViewTable.jsx
@@ -114,17 +114,26 @@ const DATAKEYS_WITH_SUBKEYS = [
   "other_metrics",
 ];
 
-const DEFAULT_COLUMNS = columnDefinitions
-  .filter(colDef => colDef?.initialCol)
-  .map(colDef => colDef.key);
-
-const DROPDOWN_COLUMNS = columnDefinitions
-  .filter(colDef => colDef.type === "dropdown")
-  .map(colDef => colDef.key);
-
-const SLIDER_COLUMNS = columnDefinitions
-  .filter(colDef => colDef.type === "slider")
-  .map(colDef => colDef.key);
+const DEFAULT_COLUMNS = [];
+const DROPDOWN_COLUMNS = [];
+const SLIDER_COLUMNS = [];
+const SLIDER_NATURAL_COLUMNS = [];
+const SLIDER_GROWTH_COLUMNS = [];
+columnDefinitions.forEach((colDef) => {
+  if ( colDef?.initialCol ) {
+    DEFAULT_COLUMNS.push(colDef.key);
+  }
+  if ( colDef.type === "dropdown" ) {
+    DROPDOWN_COLUMNS.push(colDef.key);
+  } else if ( colDef.type === "slider" ) {
+    SLIDER_COLUMNS.push(colDef.key);
+    if ( colDef?.isGrowthStat ) {
+      SLIDER_GROWTH_COLUMNS.push(colDef.key);
+    } else {
+      SLIDER_NATURAL_COLUMNS.push(colDef.key);
+    }
+  }
+});
 
 const ALL_COLUMNS = [
   ...DROPDOWN_COLUMNS,
@@ -133,7 +142,8 @@ const ALL_COLUMNS = [
 
 const DEFAULT_FILTER_VALUES = {
   ...DROPDOWN_COLUMNS.reduce((obj, e) => { obj[e] = []; return obj; }, {}),
-  ...SLIDER_COLUMNS.reduce((obj, e) => { obj[e] = [0, 100]; return obj; }, {}),
+  ...SLIDER_NATURAL_COLUMNS.reduce((obj, e) => { obj[e] = [0, 100]; return obj; }, {}),
+  ...SLIDER_GROWTH_COLUMNS.reduce((obj, e) => { obj[e] = [-100, 100]; return obj; }, {}),
 };
 const initialVal = (key) => {
   return DEFAULT_FILTER_VALUES[key]?.join(',') ?? '';
@@ -387,8 +397,9 @@ const ListViewTable = ({
 
   // Prepare the columns that we will display in the `<Table>`, including
   // adding the appropriate filter mechanisms to the header cells.
+  const columnsParamSplit = columnsParam.split(',');
   const columns = columnDefinitions
-    .filter(colDef => columnsParam.includes(colDef.key))
+    .filter(colDef => columnsParamSplit.includes(colDef.key))
     .map((colDef) => {
       let display_name;
       switch ( colDef.type ) {

--- a/web/gui-v2/src/static_data/table_columns.js
+++ b/web/gui-v2/src/static_data/table_columns.js
@@ -98,13 +98,14 @@ const columnDefinitions = [
     minWidth: 120,
     type: 'dropdown',
   },
-  {
-    title: "Sector",
-    key: "sector",
-    initialCol: false,
-    minWidth: 200,
-    type: 'dropdown',
-  },
+  // TODO, pending #120 adding `sector` data
+  // {
+  //   title: "Sector",
+  //   key: "sector",
+  //   initialCol: false,
+  //   minWidth: 200,
+  //   type: 'dropdown',
+  // },
 
   {
     title: "All publications",
@@ -140,10 +141,26 @@ const columnDefinitions = [
     ...generateSliderColDef("articles", "ai_publications"),
     initialCol: true,
   },
+  // TODO, pending clarification of intent
+  // {
+  //   title: "Citations per AI paper",
+  //   key: "citations_per_ai_pub",
+  //   ...generateSliderColDef("articles", "??????"),
+  // },
   {
     title: "AI publications in top conferences",
     key: "ai_pubs_top_conf",
     ...generateSliderColDef("articles", "ai_pubs_top_conf"),
+  },
+  {
+    title: `AI papers in last complete year (${overall.endArticleYear})`,
+    key: "ai_pubs_last_full_year",
+    ...generateSliderColDef(
+      "articles",
+      "ai_publications",
+      ((_val, row) => row.articles.ai_publications.counts[endArticleIx]),
+      (val, row, extract) => <CellStat data={{ total: extract(val, row) }} />,
+    ),
   },
   {
     title: "CV publications",
@@ -161,6 +178,17 @@ const columnDefinitions = [
     ...generateSliderColDef("articles", "robotics_pubs"),
   },
 
+  // TODO, pending #125 adding the `all_patents` data
+  // {
+  //   title: "5-year growth in patents",
+  //   key: "all_patents_growth",
+  //   ...generateSliderColDef(
+  //     "patents",
+  //     "all_patents",
+  //     ((_val, row) => 1234), // TODO
+  //     (val, row, extract) => <CellStat data={{ total: extract(val, row) }} />,
+  //   ),
+  // },
   {
     title: "AI patents",
     key: "ai_patents",

--- a/web/gui-v2/src/static_data/table_columns.js
+++ b/web/gui-v2/src/static_data/table_columns.js
@@ -129,6 +129,7 @@ const columnDefinitions = [
         return <CellStat data={{ total }} />;
       },
     ),
+    isGrowthStat: true,
   },
   {
     title: "Citation counts",
@@ -188,6 +189,7 @@ const columnDefinitions = [
   //     ((_val, row) => 1234), // TODO
   //     (val, row, extract) => <CellStat data={{ total: extract(val, row) }} />,
   //   ),
+  //   isGrowthStat: true,
   // },
   {
     title: "AI patents",

--- a/web/gui-v2/src/static_data/table_columns.js
+++ b/web/gui-v2/src/static_data/table_columns.js
@@ -357,6 +357,14 @@ const columnDefinitions = [
 ];
 export default columnDefinitions;
 
+// Filtering down to the default columns in `ListViewTable.jsx` was causing
+// filters to not persist across page refreshes.  Doing that filtering here
+// seems to be fine, but if there are subsequent issues try hardcoding the
+// array instead.  (see https://github.com/georgetown-cset/parat/issues/144)
+export const DEFAULT_COLUMNS = columnDefinitions
+  .filter(e => e?.initialCol)
+  .map(e => e.key);
+
 export const articleMap = Object.fromEntries(columnDefinitions
   .filter(e => e.dataKey === 'articles')
   .map(e => ([e.dataSubkey, e.title]))


### PR DESCRIPTION
Resolve a lack of persistence of column slider filters by moving the default column array to the general column definitions file instead of in ListViewTable.

If the persistence issues return, try just hardcoding `DEFAULT_COLUMNS` instead of building it using `initialCol`.

Closes #144

### TODO: Re-target branch after #154 is merged