### PR TITLE
Add more memory to the deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
         npm install
     - name: 'Build assets'
       env:
-        NODE_OPTIONS: "--max_old_space_size=4096"
+        NODE_OPTIONS: "--max_old_space_size=6144"
       working-directory: web/gui-v2
       run: |
         npm install -g gatsby-cli


### PR DESCRIPTION
Add more memory to the deployment workflow to bring it inline with the `package.json` memory levels and resolve errors.