### PR TITLE
GUI updates for spoofed data

### DIFF
--- a/web/gui-v2/package-lock.json
+++ b/web/gui-v2/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@emotion/react": "^11.11.1",
-        "@eto/eto-ui-components": "^1.6.0",
+        "@eto/eto-ui-components": "^1.6.1",
         "@mdx-js/react": "^2.3.0",
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.13.5",
@@ -2291,9 +2291,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/@eto/eto-ui-components": {
-      "version": "1.6.0",
-      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/eto-ui-components/-/@eto/eto-ui-components-1.6.0.tgz",
-      "integrity": "sha512-Ny88cmzl+yrbhpSGX6XsKpK+BOHktvRfg/I3z3fSulcEOYF7VEys420Hone+n6176KB9QalDln6a3HkvEpK/hQ==",
+      "version": "1.6.1",
+      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/eto-ui-components/-/@eto/eto-ui-components-1.6.1.tgz",
+      "integrity": "sha512-vXU0p7gR4QyPgNoaPD65fDN73SYhlpUMkf5htJ/0M9OGnc2HamWzA8bXdYGdFS+1H9tXeHoE0A5z1QaA1O6LxQ==",
       "dependencies": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
@@ -25305,9 +25305,9 @@
       }
     },
     "@eto/eto-ui-components": {
-      "version": "1.6.0",
-      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/eto-ui-components/-/@eto/eto-ui-components-1.6.0.tgz",
-      "integrity": "sha512-Ny88cmzl+yrbhpSGX6XsKpK+BOHktvRfg/I3z3fSulcEOYF7VEys420Hone+n6176KB9QalDln6a3HkvEpK/hQ==",
+      "version": "1.6.1",
+      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/eto-ui-components/-/@eto/eto-ui-components-1.6.1.tgz",
+      "integrity": "sha512-vXU0p7gR4QyPgNoaPD65fDN73SYhlpUMkf5htJ/0M9OGnc2HamWzA8bXdYGdFS+1H9tXeHoE0A5z1QaA1O6LxQ==",
       "requires": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",

--- a/web/gui-v2/package.json
+++ b/web/gui-v2/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",
-    "@eto/eto-ui-components": "^1.6.0",
+    "@eto/eto-ui-components": "^1.6.1",
     "@mdx-js/react": "^2.3.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.5",

--- a/web/gui-v2/src/components/DetailViewIntro.jsx
+++ b/web/gui-v2/src/components/DetailViewIntro.jsx
@@ -70,7 +70,7 @@ const DetailViewIntro = ({
 
   const metadata = [
     { title: "Country", value: data.country },
-    { title: "Sector", value: "--TODO--" },
+    { title: "Sector", value: data.sector },
     { title: "Website", value: data.website ? <ExternalLink href={data.website}>{data.website}</ExternalLink> : undefined },
   ];
 

--- a/web/gui-v2/src/components/DetailViewPatents.jsx
+++ b/web/gui-v2/src/components/DetailViewPatents.jsx
@@ -153,8 +153,16 @@ const DetailViewPatents = ({
         css={styles.section}
         data={[
           [
-            aiSubfieldOptions.find(e => e.val === aiSubfield)?.text,
+            `${aiSubfieldOptions.find(e => e.val === aiSubfield)?.text} patents at ${data.name}`,
             data.patents[aiSubfield].counts
+          ],
+          data.groups.sp500 && [
+            "S&P 500",
+            overall.groups.sp500.patents[aiSubfield].counts
+          ],
+          data.groups.global500 && [
+            "Fortune Global 500",
+            overall.groups.global500.patents[aiSubfield].counts
           ],
         ]}
         id="ai-subfield-patents"
@@ -165,6 +173,7 @@ const DetailViewPatents = ({
             Trends in {data.name}'s patenting in
             <Autocomplete
               css={styles.trendsDropdown}
+              disableClearable={true}
               inputLabel="patent subfield"
               options={aiSubfieldOptions}
               selected={aiSubfield}

--- a/web/gui-v2/src/components/DetailViewPatents.jsx
+++ b/web/gui-v2/src/components/DetailViewPatents.jsx
@@ -57,7 +57,8 @@ const DetailViewPatents = ({
 
   const aiPatentStart = data.patents.ai_patents.counts[startIx];
   const aiPatentEnd = data.patents.ai_patents.counts[endIx];
-  const aiPatentGrowth = Math.round((aiPatentEnd - aiPatentStart) / aiPatentStart * 1000) / 10
+  const aiPatentGrowth = Math.round((aiPatentEnd - aiPatentStart) / aiPatentStart * 1000) / 10;
+  const aiPatentPercent = Math.round(data.patents.ai_patents.total / data.patents.all_patents.total * 1000) / 10
 
   const statGridEntries = [
     {
@@ -77,7 +78,7 @@ const DetailViewPatents = ({
     },
     {
       key: "ai-focused-percent",
-      stat: <>NUM%</>,
+      stat: <>{aiPatentPercent}%</>,
       text: <>of {data.name}'s total patenting was AI-focused</>,
     },
   ];

--- a/web/gui-v2/src/components/DetailViewPatents.jsx
+++ b/web/gui-v2/src/components/DetailViewPatents.jsx
@@ -72,7 +72,7 @@ const DetailViewPatents = ({
     },
     {
       key: "ai-patent-applications",
-      stat: <>NUM</>,
+      stat: <>{commas(data.patents.ai_patent_applications.total)}</>,
       text: <div>AI patent <strong>applications</strong> were filed by {data.name} ({yearSpanNdash})</div>,
     },
     {

--- a/web/gui-v2/src/components/DetailViewPublications.jsx
+++ b/web/gui-v2/src/components/DetailViewPublications.jsx
@@ -70,8 +70,8 @@ const DetailViewPublications = ({
     },
     {
       key: "highly-cited",
-      stat: <>NUMBER</>,
-      text: <>highly-cited articles (#RANK in PARAT, #RANK in the S&P 500)</>,
+      stat: <>{commas(data.articles.highly_cited.total)}</>,
+      text: <>highly-cited articles (#{commas(data.articles.highly_cited.rank)} in PARAT, #RANK in the S&P 500)</>,
     },
     {
       key: "ai-research-growth",
@@ -140,8 +140,16 @@ const DetailViewPublications = ({
         css={styles.section}
         data={[
           [
-            aiSubfieldOptions.find(e => e.val === aiSubfield)?.text,
+            `${aiSubfieldOptions.find(e => e.val === aiSubfield)?.text} research at ${data.name}`,
             data.articles[aiSubfield].counts
+          ],
+          data.groups.sp500 && [
+            "S&P 500",
+            overall.groups.sp500.articles[aiSubfield].counts
+          ],
+          data.groups.global500 && [
+            "Fortune Global 500",
+            overall.groups.global500.articles[aiSubfield].counts
           ],
         ]}
         id="ai-subfield-research"
@@ -166,7 +174,18 @@ const DetailViewPublications = ({
       <TrendsChart
         css={styles.section}
         data={[
-          ["AI top conference publications", data.articles.ai_pubs_top_conf.counts],
+          [
+            `AI top conference publications at ${data.name}`,
+            data.articles.ai_pubs_top_conf.counts
+          ],
+          data.groups.sp500 && [
+            "S&P 500",
+            overall.groups.sp500.articles.ai_pubs_top_conf.counts
+          ],
+          data.groups.global500 && [
+            "Fortune Global 500",
+            overall.groups.global500.articles.ai_pubs_top_conf.counts
+          ],
         ]}
         id="ai-top-conference-pubs-2"
         layoutChanges={chartLayoutChanges}

--- a/web/gui-v2/src/components/ListViewTable.jsx
+++ b/web/gui-v2/src/components/ListViewTable.jsx
@@ -133,7 +133,7 @@ const styles = {
  * }} FilterStateObject
  */
 
-const GROUPS_OPTIONS = Object.entries(overallData.groups).map(([k, v]) => ({ text: v, val: `GROUP:${k}` }));
+const GROUPS_OPTIONS = Object.entries(overallData.groups).map(([k, v]) => ({ text: v.name, val: `GROUP:${k}` }));
 
 const DATAKEYS_WITH_SUBKEYS = [
   "articles",

--- a/web/gui-v2/src/components/TrendsChart.jsx
+++ b/web/gui-v2/src/components/TrendsChart.jsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 
 import SectionHeading from './SectionHeading';
 import { fallback } from '../styles/common-styles';
+import { cleanFalse } from '../util';
 import { assemblePlotlyParams } from '../util/plotly-helpers';
 
 const Plot = lazy(() => import('react-plotly.js'));
@@ -56,7 +57,7 @@ const TrendsChart = ({
   title,
   years,
 }) => {
-  const { config, data, layout } = assemblePlotlyParams(years, dataRaw, layoutChanges, { partialStartIndex });
+  const { config, data, layout } = assemblePlotlyParams(years, cleanFalse(dataRaw), layoutChanges, { partialStartIndex });
 
   return (
     <div

--- a/web/gui-v2/src/static_data/table_columns.js
+++ b/web/gui-v2/src/static_data/table_columns.js
@@ -114,6 +114,21 @@ const columnDefinitions = [
     ...generateSliderColDef("articles", "all_publications"),
   },
   {
+    title: "5-year total publications",
+    key: "all_pubs_5yr",
+    ...generateSliderColDef(
+      "articles",
+      "all_publications",
+      ((_val, row) => {
+        const data = row.articles.all_publications;
+        return data.counts.slice(startArticleIx, endArticleIx+1).reduce((acc, curr) => acc + curr);
+      }),
+      (val, row, extract) => {
+        return <CellStat data={{ total: extract(val, row) }} />;
+      },
+    ),
+  },
+  {
     title: "5-year growth in publications",
     key: "all_pubs_growth",
     ...generateSliderColDef(
@@ -142,6 +157,22 @@ const columnDefinitions = [
     key: "ai_pubs",
     ...generateSliderColDef("articles", "ai_publications"),
     initialCol: true,
+  },
+  {
+    title: "AI publication percentage",
+    key: "ai_pubs_percent",
+    ...generateSliderColDef(
+      "articles",
+      "ai_pubs",
+      ((_val, row) => {
+        return Math.round(row.articles.ai_publications.total / row.articles.all_publications.total * 1000) / 10;
+      }),
+      (val, row, extract) => {
+        const extractedVal = extract(val, row);
+        const total = extractedVal ? `${extractedVal.toFixed(1)}%` : '---';
+        return <CellStat data={{ total }} />
+      },
+    ),
   },
   // TODO, pending clarification of intent
   // {
@@ -186,6 +217,21 @@ const columnDefinitions = [
     ...generateSliderColDef("patents", "all_patents"),
   },
   {
+    title: "5-year total patents",
+    key: "all_patents_5yr",
+    ...generateSliderColDef(
+      "patents",
+      "all_patents",
+      ((_val, row) => {
+        const data = row.patents.all_patents;
+        return data.counts.slice(startPatentIx, endPatentIx+1).reduce((acc, curr) => acc + curr);
+      }),
+      (val, row, extract) => {
+        return <CellStat data={{ total: extract(val, row) }} />;
+      },
+    ),
+  },
+  {
     title: "5-year growth in patents",
     key: "all_patents_growth",
     ...generateSliderColDef(
@@ -209,6 +255,22 @@ const columnDefinitions = [
     key: "ai_patents",
     ...generateSliderColDef("patents", "ai_patents"),
     initialCol: true,
+  },
+  {
+    title: "AI patent percentage",
+    key: "ai_patents_percent",
+    ...generateSliderColDef(
+      "patents",
+      "ai_patents",
+      ((_val, row) => {
+        return Math.round(row.patents.ai_patents.total / row.patents.all_patents.total * 1000) / 10;
+      }),
+      (val, row, extract) => {
+        const extractedVal = extract(val, row);
+        const total = extractedVal ? `${extractedVal.toFixed(1)}%` : '---';
+        return <CellStat data={{ total }} />
+      },
+    ),
   },
   {
     title: "Applications for AI patents",

--- a/web/gui-v2/src/static_data/table_columns.js
+++ b/web/gui-v2/src/static_data/table_columns.js
@@ -7,6 +7,8 @@ import { slugifyCompanyName } from '../util';
 
 const startArticleIx = overall.years.findIndex(e => e === overall.startArticleYear);
 const endArticleIx = overall.years.findIndex(e => e === overall.endArticleYear);
+const startPatentIx = overall.years.findIndex(e => e === overall.startPatentYear);
+const endPatentIx = overall.years.findIndex(e => e === overall.endPatentYear);
 
 const styles = {
   name: css`
@@ -98,14 +100,13 @@ const columnDefinitions = [
     minWidth: 120,
     type: 'dropdown',
   },
-  // TODO, pending #120 adding `sector` data
-  // {
-  //   title: "Sector",
-  //   key: "sector",
-  //   initialCol: false,
-  //   minWidth: 200,
-  //   type: 'dropdown',
-  // },
+  {
+    title: "Sector",
+    key: "sector",
+    initialCol: false,
+    minWidth: 200,
+    type: 'dropdown',
+  },
 
   {
     title: "All publications",
@@ -179,23 +180,40 @@ const columnDefinitions = [
     ...generateSliderColDef("articles", "robotics_pubs"),
   },
 
-  // TODO, pending #125 adding the `all_patents` data
-  // {
-  //   title: "5-year growth in patents",
-  //   key: "all_patents_growth",
-  //   ...generateSliderColDef(
-  //     "patents",
-  //     "all_patents",
-  //     ((_val, row) => 1234), // TODO
-  //     (val, row, extract) => <CellStat data={{ total: extract(val, row) }} />,
-  //   ),
-  //   isGrowthStat: true,
-  // },
+  {
+    title: "All patents",
+    key: "all_patents",
+    ...generateSliderColDef("patents", "all_patents"),
+  },
+  {
+    title: "5-year growth in patents",
+    key: "all_patents_growth",
+    ...generateSliderColDef(
+      "patents",
+      "all_patents",
+      ((_val, row) => {
+        const data = row.patents.all_patents;
+        const startVal = data.counts[startPatentIx];
+        return Math.round((data.counts[endPatentIx] - startVal) / startVal * 1000) / 10;
+      }),
+      (val, row, extract) => {
+        const extractedVal = extract(val, row);
+        const total = extractedVal ? `${extractedVal.toFixed(1)}%` : '---';
+        return <CellStat data={{ total }} />
+      },
+    ),
+    isGrowthStat: true,
+  },
   {
     title: "AI patents",
     key: "ai_patents",
     ...generateSliderColDef("patents", "ai_patents"),
     initialCol: true,
+  },
+  {
+    title: "Applications for AI patents",
+    key: "ai_patent_applications",
+    ...generateSliderColDef("patents", "ai_patent_applications"),
   },
   {
     title: "Agricultural patents",

--- a/web/gui-v2/src/util/index.js
+++ b/web/gui-v2/src/util/index.js
@@ -4,6 +4,8 @@ import slugify from 'slugify';
 export { useMultiState } from './useMultiState';
 export { useWindowSize } from './useWindowSize';
 
+export const cleanFalse = (array) => array.filter(e => e !== false);
+
 export const commas = (num) => num?.toLocaleString() ?? "";
 
 export function debounce(callback, wait) {


### PR DESCRIPTION
Update the GUI to incorporate the addition of the spoofed data in #169:
* Adjust for new structure to `overall.groups`
* Add group comparison lines to detail view graphs (closes #84)
* Add sector, highly-cited, patent applications, and patent AI percent to detail view
* Add columns for:
  * Sector
  * AI pub percent
  * AI pub 5-year total
  * All patents
  * Patent applications
  * AI patent percent
  * AI patent 5-year total
* Ensure that the patent trends autocomplete menu always has something selected