### PR TITLE
Filter out fields with no yearly counts from trends data

### DIFF
--- a/web/gui-v2/src/components/DetailViewPatents.jsx
+++ b/web/gui-v2/src/components/DetailViewPatents.jsx
@@ -120,6 +120,7 @@ const DetailViewPatents = ({
     .sort((a, b) => b.patents - a.patents);
 
   const aiSubfieldOptions = patentSubkeys
+    .filter(k => !!data.patents[k]?.counts)
     .map(k => ({ text: patentMap[k].replace(/ patents/i, ''), val: k }))
     .sort((a, b) => a.text.localeCompare(b.text, 'en', { sensitivity: 'base' }));
 


### PR DESCRIPTION
Don't list fields that do not contain yearly counts in the dropdown for the patent trends chart.

Closes #174