### PR TITLE
Restore persistence to slider columns

### DIFF
--- a/web/gui-v2/src/components/HeaderSlider.jsx
+++ b/web/gui-v2/src/components/HeaderSlider.jsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { Slider } from '@mui/material';
 
 import { debounce } from '../util';
+import { parseSlider } from '../util/list-filters';
 
 const styles = {
   wrapper: css`
@@ -23,12 +24,13 @@ const styles = {
 };
 
 const HeaderSlider = ({
+  initialValue,
   label,
   min=0,
   onChange,
   value,
 }) => {
-  const [valueInternal, setValueInternal] = useState(value);
+  const [valueInternal, setValueInternal] = useState(() => parseSlider(initialValue) ?? value);
 
   // Update internal value based on external changes
   useEffect(

--- a/web/gui-v2/src/components/ListViewTable.jsx
+++ b/web/gui-v2/src/components/ListViewTable.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useQueryParamString } from 'react-use-query-param-string';
+import { getQueryParams, useQueryParamString } from 'react-use-query-param-string';
 import { css } from '@emotion/react';
 import {
   AddCircleOutline as AddCircleOutlineIcon,
@@ -313,6 +313,8 @@ const ListViewTable = ({
   const [sortKey, setSortKey] = useState('ai_pubs');
   const isFirstRender = useRef(true);
 
+  const [initialQueryParams] = useState(() => getQueryParams());
+
   // Using param name 'zz_columns' to keep the columns selection at the end of
   // the URL.  I'm theorizing that users are most likely to care about the other
   // filters when looking at the URL, so it makes sense that filter params like
@@ -453,6 +455,7 @@ const ListViewTable = ({
         case 'slider':
           display_name = (
             <HeaderSlider
+              initialValue={initialQueryParams?.[colDef.key]}
               label={colDef.title}
               onChange={newVal => handleSliderChange(colDef.key, newVal)}
               value={filters?.[colDef.key].get}

--- a/web/gui-v2/src/util/list-filters.js
+++ b/web/gui-v2/src/util/list-filters.js
@@ -1,0 +1,11 @@
+
+
+
+export const parseSlider = (val) => {
+  return val?.split(',').map(e => parseInt(e));
+}
+
+export const parseOther = (val) => {
+  return val?.split(',').filter(e => e !== "");
+}
+

--- a/web/gui-v2/src/util/list-filters.test.js
+++ b/web/gui-v2/src/util/list-filters.test.js
@@ -1,0 +1,20 @@
+
+import {
+  parseSlider,
+  parseOther,
+} from './list-filters';
+
+describe("helper functions for list view filters", () => {
+  it("slider filters are parsed as expected", () => {
+    expect(parseSlider("0,100")).toEqual([0, 100]);
+    expect(parseSlider("0,64")).toEqual([0, 64]);
+    expect(parseSlider("-100,50")).toEqual([-100, 50]);
+  });
+
+  it("other filters are parsed as expected", () => {
+    expect(parseOther("")).toEqual([]);
+    expect(parseOther("example")).toEqual(["example"]);
+    expect(parseOther("alpha,beta")).toEqual(["alpha", "beta"]);
+  });
+});
+


### PR DESCRIPTION
Fix state mismatch issues that led to slider column filter values not persisting across page refreshes.

Dropdown filters still have persistence issues.

Closes #144