### PR TITLE
Fix persistence issue with header dropdowns

### DIFF
--- a/web/gui-v2/src/components/ListViewTable.jsx
+++ b/web/gui-v2/src/components/ListViewTable.jsx
@@ -350,6 +350,18 @@ const ListViewTable = ({
     }
   );
 
+  // Re-establish dropdown filter values that we receive from the URL parameters
+  // but were overwritten by the Autocomplete in HeaderDropdown, causing the
+  // dropdown filters to not persist across page refreshes
+  // (see https://github.com/georgetown-cset/parat/issues/179)
+  useEffect(() => {
+    DROPDOWN_COLUMNS.forEach((key) => {
+      if ( initialQueryParams?.[key] ) {
+        filters[key].set(initialQueryParams[key].split(','));
+      }
+    });
+  }, []);
+
   // Read-only object of the currently-set values of the filters
   const currentFilters = useMemo(
     () => extractCurrentFilters(filters),


### PR DESCRIPTION
Resolve issue where the default value for a dropdown filter was being passed to the underlying `<Autocomplete>` before the desired filter value retrieved from the URL parameters could be provided, leading to the Autocomplete overwriting the desired value with the default value.  To fix this, update the dropdown filters with the initial filter state in a first-render `useEffect` call, which occurs after the unwanted overwriting but before any user interactions could occur.

Closes #179