### PR TITLE
Fix height of Plotly wrappers

### DIFF
--- a/web/gui-v2/package-lock.json
+++ b/web/gui-v2/package-lock.json
@@ -7533,9 +7533,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001487",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
-      "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA==",
+      "version": "1.0.30001578",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001578.tgz",
+      "integrity": "sha512-J/jkFgsQ3NEl4w2lCoM9ZPxrD+FoBNJ7uJUpGVjIg/j0OwJosWM36EPDv+Yyi0V4twBk9pPmlFS+PLykgEvUmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -29200,9 +29200,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001487",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
-      "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA=="
+      "version": "1.0.30001578",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001578.tgz",
+      "integrity": "sha512-J/jkFgsQ3NEl4w2lCoM9ZPxrD+FoBNJ7uJUpGVjIg/j0OwJosWM36EPDv+Yyi0V4twBk9pPmlFS+PLykgEvUmg=="
     },
     "canvas-fit": {
       "version": "1.5.0",

--- a/web/gui-v2/src/components/TrendsChart.jsx
+++ b/web/gui-v2/src/components/TrendsChart.jsx
@@ -1,6 +1,8 @@
 import React, { Suspense, lazy } from 'react';
 import { css } from '@emotion/react';
 
+import { breakpoints } from '@eto/eto-ui-components';
+
 import SectionHeading from './SectionHeading';
 import { fallback } from '../styles/common-styles';
 import { cleanFalse } from '../util';
@@ -33,6 +35,14 @@ const styles = {
     flex-direction: column;
     margin: 0.5rem auto 0;
     max-width: 1000px;
+
+    .plotly.plot-container {
+      height: 360px;
+
+      ${breakpoints.phone_large} {
+        height: 450px;
+      }
+    }
   `,
 };
 

--- a/web/gui-v2/src/components/TrendsChart.jsx
+++ b/web/gui-v2/src/components/TrendsChart.jsx
@@ -37,11 +37,7 @@ const styles = {
     max-width: 1000px;
 
     .plotly.plot-container {
-      height: 360px;
-
-      ${breakpoints.phone_large} {
-        height: 450px;
-      }
+      height: 450px;
     }
   `,
 };


### PR DESCRIPTION
The `div.svg-container` elements wrapping the Plotly SVG charts was getting `height: 100%;` set under certain viewport widths (instead of the fixed height set under other viewport widths), which led to the charts overlapping each other and other content.  By fixing the height of div above that one, we can keep the chart dimensions consistent.

Made the charts slightly smaller on phone-sized viewports since they didn't seem to need to be quite as tall in that case.

Updated browserslist DB

Closes #116