### PR TITLE
Add ARIA labels for the individual thumbs of `<Slider>`.

### DIFF
--- a/web/gui-v2/src/components/HeaderSlider.jsx
+++ b/web/gui-v2/src/components/HeaderSlider.jsx
@@ -56,6 +56,7 @@ const HeaderSlider = ({
     <div css={styles.wrapper}>
       <Slider
         css={styles.slider}
+        getAriaLabel={(index) => index === 0 ? "Lower bound" : "Upper bound"}
         min={min}
         max={max}
         onChange={(newVal) => setValueInternal(newVal.target.value)}


### PR DESCRIPTION
Additional accessibility improvement that was missed in #204

Closes #16