### PR TITLE
Add tooltips for column headers and S&P 500

### DIFF
--- a/web/gui-v2/src/components/ListViewTable.jsx
+++ b/web/gui-v2/src/components/ListViewTable.jsx
@@ -24,6 +24,7 @@ import HeaderDropdown from './HeaderDropdown';
 import HeaderSlider from './HeaderSlider';
 import overallData from '../static_data/overall_data.json';
 import columnDefinitions, { columnKeyMap } from '../static_data/table_columns';
+import { tooltips } from '../static_data/tooltips';
 import {
   commas,
   useMultiState,
@@ -133,6 +134,28 @@ const styles = {
       font-family: GTZirkonLight;
     }
   `,
+  dropdownEntryWithTooltip: css`
+    align-items: center;
+    display: flex;
+  `,
+  groupExplanationTooltip: css`
+    .MuiTooltip-tooltip {
+      max-width: 450px;
+
+      ul {
+        margin: 0.5rem 0;
+        padding-left: 20px;
+
+        li {
+          font-family: GTZirkonLight;
+        }
+
+        li + li {
+          margin-top: 0.5rem;
+        }
+      }
+    }
+  `,
   shortDropdown: css`
     .MuiPaper-root {
       max-height: 192px;
@@ -179,7 +202,18 @@ const styles = {
  * }} FilterStateObject
  */
 
-const GROUPS_OPTIONS = Object.entries(overallData.groups).map(([k, v]) => ({ text: v.name, val: `GROUP:${k}` }));
+const GROUPS_OPTIONS = Object.entries(overallData.groups)
+  .map(([k, v]) => ({
+    text: (
+      tooltips?.groupExplanations?.[k] ?
+        <div css={styles.dropdownEntryWithTooltip}>
+          {v.name} <HelpTooltip css={styles.groupExplanationTooltip} text={tooltips.groupExplanations[k]} />
+        </div>
+      :
+        v.name
+    ),
+    val: `GROUP:${k}`,
+  }));
 
 const DATAKEYS_WITH_SUBKEYS = [
   "articles",
@@ -546,7 +580,14 @@ const ListViewTable = ({
       }
       const column = {
         ...colDef,
-        display_name: <label>{colDef.title}</label>,
+        display_name: (
+          tooltips.columnHeaders?.[colDef.key] ?
+            <HelpTooltip text={tooltips.columnHeaders[colDef.key]}>
+              <label>{colDef.title}</label>
+            </HelpTooltip>
+          :
+            <label>{colDef.title}</label>
+        ),
         subheading,
       };
       return column;

--- a/web/gui-v2/src/static_data/table_columns.js
+++ b/web/gui-v2/src/static_data/table_columns.js
@@ -208,7 +208,6 @@ const columnDefinitions = [
       },
     ),
     isGrowthStat: true,
-    tooltip: "Average yearly growth over the past 3 years",
   },
   {
     title: "AI publication percentage",
@@ -307,7 +306,6 @@ const columnDefinitions = [
       },
     ),
     isGrowthStat: true,
-    tooltip: "Average yearly growth over the past 3 years",
   },
   {
     title: "AI patent percentage",

--- a/web/gui-v2/src/static_data/tooltips.js
+++ b/web/gui-v2/src/static_data/tooltips.js
@@ -1,8 +1,85 @@
+import React from 'react';
+
+import { ExternalLink } from '@eto/eto-ui-components';
+
 const tooltips = {
-  "included_subsidiaries": "PARAT treats these subsidiaries as part of the parent company.",
-  "excluded_subsidiaries": "PARAT treats these subsidiaries as separate from the parent company; they have their own records.",
-  "grid": "GRID is used to identify organizations in academic publication databases.",
-  "permid": "PermID is used to identify organizations in PermID-compatible investment databases."
+  columnHeaders: {
+    name: "",
+    country: "",
+    continent: "",
+    stage: "",
+    sector: "",
+
+    all_pubs: "",
+    all_pubs_5yr: "",
+    citations: "",
+    ai_pubs: "",
+    ai_pubs_growth: "Average yearly growth over the past 3 years",
+    ai_pubs_percent: "",
+    ai_pubs_top_conf: "",
+    ai_pubs_last_full_year: "",
+    cv_pubs: "",
+    nlp_pubs: "",
+    ro_pubs: "",
+
+    all_patents: "",
+    all_patents_5yr: "",
+    ai_patents: "",
+    ai_patents_growth: "Average yearly growth over the past 3 years",
+    ai_patents_percent: "",
+    ai_patents_grants: "",
+    agri_patents: "",
+    algorithms: "",
+    finance_patents: "",
+    business_patents: "",
+    comp_vision: "",
+    comp_in_gov_patents: "",
+    control: "",
+    distributed_ai: "",
+    doc_mgt_patents: "",
+    edu_patents: "",
+    entertain_patents: "",
+    industry_patents: "",
+    knowledge_rep: "",
+    lang_process: "",
+    life_patents: "",
+    measure_test: "",
+    mil_patents: "",
+    nano_patents: "",
+    network_patents: "",
+    personal_comp_patents: "",
+    phys_sci_patents: "",
+    plan_sched: "",
+    robotics: "",
+    security_patents: "",
+    semiconductor_patents: "",
+    speech: "",
+    telecom_patents: "",
+    transport_patents: "",
+
+    ai_jobs: "",
+    tt1_jobs: "",
+  },
+  groupExplanations: {
+    sp500: (
+      <>
+        PARAT may not list exactly 500 companies for this group:
+        <ul>
+          <li>
+            S&P 500 membership changes over time, and so PARAT includes all companies
+            that were present on the list at <em>some</em> point in 2020.  This can
+            increase the number of listed companies.
+          </li>
+          <li>
+            Companies that were acquired during the data period will be listed under
+            the acquiring company, even if that company is not itself on the S&P 500.
+            This can reduce the number of listed companies.
+          </li>
+        </ul>
+        For more information, review <ExternalLink href="https://eto.tech/tool-docs/parat#SOME_METHODOLOGY_SECTION">our documentation</ExternalLink>.
+      </>
+    ),
+  },
 };
 
 export { tooltips };


### PR DESCRIPTION
Add system for defining tooltips:
* Add unflagged tooltips to the list view column headers (closes #91)
* Add system for tooltips to explain/define company groups, like S&P 500.  (closes #187)