### PR TITLE
Constrain width of detail view contents

### DIFF
--- a/web/gui-v2/src/components/DetailView.jsx
+++ b/web/gui-v2/src/components/DetailView.jsx
@@ -81,7 +81,7 @@ const styles = {
     top: 0px;
   `,
   contentsArea: css`
-    /* grid-area: contents; */
+    max-width: calc(100vw - 51px);
   `,
 };
 


### PR DESCRIPTION
Limit the max width of the contents of the detail view to ensure the page doesn't get too wide on small viewports (like the iPhone 13's small, 390px viewport).

Closes #264