### PR TITLE
Add placeholder tooltip for Fortune Global 500

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -45,3 +45,11 @@ gatsby build
 ```
 
 And copy the files in the resulting `public` directory to the production bucket. 
+
+### Tooltips
+
+Tooltips are defined in [`src/static_data/tooltips.js`](https://github.com/georgetown-cset/parat/blob/master/web/gui-v2/src/static_data/tooltips.js),
+and can include React fragments and Emotion styles for design and layout.
+
+Tooltips use the same keys as their associated data elements (example: S&P 500
+data uses the `sp500` key, as does the S&P 500 explainer tooltip).

--- a/web/gui-v2/src/static_data/tooltips.js
+++ b/web/gui-v2/src/static_data/tooltips.js
@@ -79,6 +79,11 @@ const tooltips = {
         For more information, review <ExternalLink href="https://eto.tech/tool-docs/parat#SOME_METHODOLOGY_SECTION">our documentation</ExternalLink>.
       </>
     ),
+    global500: (
+      <>
+        Zach_tooltip_tktktk
+      </>
+    ),
   },
 };
 


### PR DESCRIPTION
Ensure that adding tooltips for country groups is as simple as adding an entry to `tooltips.js` and add a placeholder tooltip for the Fortune Global 500.  Add a note to the README.

Closes #269