### PR TITLE
Update UIC to fix table borders

### DIFF
--- a/web/gui-v2/package-lock.json
+++ b/web/gui-v2/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@emotion/react": "^11.11.1",
-        "@eto/eto-ui-components": "^1.7.0",
+        "@eto/eto-ui-components": "^1.7.2",
         "@mdx-js/react": "^2.3.0",
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.13.5",
@@ -2295,9 +2295,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/@eto/eto-ui-components": {
-      "version": "1.7.0",
-      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/eto-ui-components/-/@eto/eto-ui-components-1.7.0.tgz",
-      "integrity": "sha512-kxB7OQK9G7PRD0V1Dol5krb1gj2f/YdDPnrcPcfdl9liCxecpD/yX+W/i1jURYVq+32D+o7LgP2SwaW+AFpC0A==",
+      "version": "1.7.2",
+      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/eto-ui-components/-/@eto/eto-ui-components-1.7.2.tgz",
+      "integrity": "sha512-K0GSc/7Va0BMEABe1iK1ZkxnrRbUxr7foYcG0V8KP9tA/Ids8JKZexZRo5RY7G4Sq7Oq87tsmjobvvfsTfvD1w==",
       "dependencies": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
@@ -25495,9 +25495,9 @@
       }
     },
     "@eto/eto-ui-components": {
-      "version": "1.7.0",
-      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/eto-ui-components/-/@eto/eto-ui-components-1.7.0.tgz",
-      "integrity": "sha512-kxB7OQK9G7PRD0V1Dol5krb1gj2f/YdDPnrcPcfdl9liCxecpD/yX+W/i1jURYVq+32D+o7LgP2SwaW+AFpC0A==",
+      "version": "1.7.2",
+      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/eto-ui-components/-/@eto/eto-ui-components-1.7.2.tgz",
+      "integrity": "sha512-K0GSc/7Va0BMEABe1iK1ZkxnrRbUxr7foYcG0V8KP9tA/Ids8JKZexZRo5RY7G4Sq7Oq87tsmjobvvfsTfvD1w==",
       "requires": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",

--- a/web/gui-v2/package.json
+++ b/web/gui-v2/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",
-    "@eto/eto-ui-components": "^1.7.0",
+    "@eto/eto-ui-components": "^1.7.2",
     "@mdx-js/react": "^2.3.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.5",


### PR DESCRIPTION
Update UI Components to 1.7.2 to resolve issues with `<Table>` borders in Safari and a [subsequent issue](https://github.com/georgetown-cset/eto-ui-components/pull/391) of double borders.

Closes #283