### PR TITLE
Display 'n/a' for jobs when no LinkedIn page available

### DIFF
--- a/web/gui-v2/src/components/DetailViewWorkforce.jsx
+++ b/web/gui-v2/src/components/DetailViewWorkforce.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { Alert } from '@eto/eto-ui-components';
+
 import HeaderWithLink from './HeaderWithLink';
 import StatBox from './StatBox';
 import StatWrapper from './StatWrapper';
@@ -17,23 +19,29 @@ const DetailViewWorkforce = ({
     <>
       <HeaderWithLink title="Workforce" />
 
-      <StatWrapper>
-        { otherMetricsWorkforceKeys.map((key) => (
-          <StatBox
-            description={
-              <>
-                From {yearSpanText}, {data.name} here is some explanatory text
-                describing how they had NUMBER jobs of the specified type
-                (#{data.other_metrics[key].rank} rank in PARAT
-                {data.in_sandp_500 && <>, #NUMBER in the S&P500</>})
-              </>
-            }
-            key={key}
-            label={otherMetricMap[key]}
-            value={data.other_metrics[key].total}
-          />
-        ))}
-      </StatWrapper>
+      {data.linkedin.length > 0 ?
+        <StatWrapper>
+          { otherMetricsWorkforceKeys.map((key) => (
+            <StatBox
+              description={
+                <>
+                  From {yearSpanText}, {data.name} here is some explanatory text
+                  describing how they had NUMBER jobs of the specified type
+                  (#{data.other_metrics[key].rank} rank in PARAT
+                  {data.in_sandp_500 && <>, #NUMBER in the S&P500</>})
+                </>
+              }
+              key={key}
+              label={otherMetricMap[key]}
+              value={data.other_metrics[key].total}
+            />
+          ))}
+        </StatWrapper>
+      :
+        <Alert>
+          ZACH_TKTK Note about no jobs due to no LinkedIn data
+        </Alert>
+      }
     </>
   );
 };

--- a/web/gui-v2/src/static_data/table_columns.js
+++ b/web/gui-v2/src/static_data/table_columns.js
@@ -581,19 +581,40 @@ const columnDefinitions = [
     ...generateSliderColDef("patents", "Transportation"),
     tooltip: "Zach_tktk",
   },
-
   {
     title: "AI jobs",
     key: "ai_jobs",
     aggregateType: "median",
-    ...generateSliderColDef("other_metrics", "ai_jobs"),
-    tooltip: "Zach_tktk",
+    ...generateSliderColDef(
+      "other_metrics",
+      "ai_jobs",
+      undefined, // Use default extract function
+      (_val, row) => {
+        if ( row?._group || row.linkedin.length > 0 ) {
+          return <CellStat data={row.other_metrics.ai_jobs} />;
+        } else {
+          return <CellStat data={{ total: null }} />
+        }
+      },
+    ),
+    tooltip: "Zach_tktk"
   },
   {
     title: "Tech Tier 1 jobs",
     key: "tt1_jobs",
     aggregateType: "median",
-    ...generateSliderColDef("other_metrics", "tt1_jobs"),
+    ...generateSliderColDef(
+      "other_metrics",
+      "tt1_jobs",
+      undefined, // Use default extract function
+      (_val, row) => {
+        if ( row?._group || row.linkedin.length > 0 ) {
+          return <CellStat data={row.other_metrics.tt1_jobs} />;
+        } else {
+          return <CellStat data={{ total: null }} />
+        }
+      },
+    ),
     initialCol: true,
     tooltip: "Zach_tktk",
   },


### PR DESCRIPTION
If a company has no LinkedIn page, display 'n/a' for the jobs counts instead of zero to not give an incorrect impression of the jobs counts.

Closes #234

![image](https://github.com/georgetown-cset/parat/assets/22353962/848ae6c1-5f56-4606-8d01-51347c46437c)


### Questions
@za158 How should the 'Workforce' section of the detail page be handled for these cases?

![image](https://github.com/georgetown-cset/parat/assets/22353962/4d936255-3168-4282-9416-03ad04602369)
