### PR TITLE
Clarify label of trend lines for groups in charts

### DIFF
--- a/web/gui-v2/src/components/DetailViewPatents.jsx
+++ b/web/gui-v2/src/components/DetailViewPatents.jsx
@@ -159,11 +159,11 @@ const DetailViewPatents = ({
             data.patents[aiSubfield].counts
           ],
           data.groups.sp500 && [
-            "S&P 500",
+            "S&P 500 (average)",
             overall.groups.sp500.patents[aiSubfield].counts
           ],
           data.groups.global500 && [
-            "Fortune Global 500",
+            "Fortune Global 500 (average)",
             overall.groups.global500.patents[aiSubfield].counts
           ],
         ]}

--- a/web/gui-v2/src/components/DetailViewPublications.jsx
+++ b/web/gui-v2/src/components/DetailViewPublications.jsx
@@ -147,11 +147,11 @@ const DetailViewPublications = ({
             data.articles[aiSubfield].counts
           ],
           data.groups.sp500 && [
-            "S&P 500",
+            "S&P 500 (average)",
             overall.groups.sp500.articles[aiSubfield].counts
           ],
           data.groups.global500 && [
-            "Fortune Global 500",
+            "Fortune Global 500 (average)",
             overall.groups.global500.articles[aiSubfield].counts
           ],
         ]}
@@ -182,11 +182,11 @@ const DetailViewPublications = ({
             data.articles.ai_pubs_top_conf.counts
           ],
           data.groups.sp500 && [
-            "S&P 500",
+            "S&P 500 (average)",
             overall.groups.sp500.articles.ai_pubs_top_conf.counts
           ],
           data.groups.global500 && [
-            "Fortune Global 500",
+            "Fortune Global 500 (average)",
             overall.groups.global500.articles.ai_pubs_top_conf.counts
           ],
         ]}


### PR DESCRIPTION
Rephrase the label on the group trend line to make it clear that it is showing the average for the group.

Closes #271