### PR TITLE
Fix weird dropdown, double negatives, and chart colors

### DIFF
--- a/web/gui-v2/src/components/DetailViewPatents.jsx
+++ b/web/gui-v2/src/components/DetailViewPatents.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
 
-import { Autocomplete } from '@eto/eto-ui-components';
+import { Dropdown } from '@eto/eto-ui-components';
 
 import HeaderWithLink from './HeaderWithLink';
 import StatGrid from './StatGrid';
@@ -22,13 +22,10 @@ const styles = {
     }
   `,
   trendsDropdown: css`
-    .MuiAutocomplete-root .MuiInput-root.MuiInputBase-sizeSmall .MuiInput-input {
-      padding: 4px;
-      text-align: center;
-    }
-
-    ul > li {
-      text-align: left;
+    .MuiInputBase-input.MuiSelect-select {
+      align-items: center;
+      display: flex;
+      justify-content: center;
     }
   `,
 };
@@ -173,7 +170,7 @@ const DetailViewPatents = ({
         title={
           <>
             Trends in {data.name}'s patenting in
-            <Autocomplete
+            <Dropdown
               css={styles.trendsDropdown}
               disableClearable={true}
               inputLabel="patent subfield"

--- a/web/gui-v2/src/components/DetailViewPublications.jsx
+++ b/web/gui-v2/src/components/DetailViewPublications.jsx
@@ -58,7 +58,7 @@ const DetailViewPublications = ({
   const aiResearchPercent = Math.round(1000 * data.articles.ai_publications.total / data.articles.all_publications.total) / 10;
 
   const aiPubsGrowthTotal = data.articles.ai_publications_growth.total;
-  const aiPubsGrowthSign = (aiPubsGrowthTotal > 0) ? '+' : (aiPubsGrowthTotal < 0) ? '-' : '';
+  const aiPubsGrowthSign = (aiPubsGrowthTotal > 0) ? '+' : '';
 
   const statGridEntries = [
     {

--- a/web/gui-v2/src/util/plotly-helpers.test.js
+++ b/web/gui-v2/src/util/plotly-helpers.test.js
@@ -23,15 +23,7 @@ describe("Plotly helpers", () => {
     });
     expect(data).toEqual([
       {
-        hovertemplate: "%{y}",
-        legendgroup: TITLE,
-        mode: "lines+markers",
-        name: TITLE,
-        type: "scatter",
-        x: [ 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 ],
-        y: [ 850, 928, 845, 843, 838, 1040, 1357, 1551, 1507, 461 ],
-      },
-      {
+        _isBackground: true,
         fill: "tozeroy",
         hovertemplate: "%{y}",
         legendgroup: TITLE,
@@ -43,6 +35,17 @@ describe("Plotly helpers", () => {
         type: "scatter",
         x: [ 2022, 2023 ],
         y: [ 461, 2 ],
+      },
+      {
+        _isBackground: false,
+        hovertemplate: "%{y}",
+        legendgroup: TITLE,
+        line: { color: "rgb(31, 119, 180)" },
+        mode: "lines+markers",
+        name: TITLE,
+        type: "scatter",
+        x: [ 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 ],
+        y: [ 850, 928, 845, 843, 838, 1040, 1357, 1551, 1507, 461 ],
       },
     ]);
     expect(layout).toEqual({


### PR DESCRIPTION
Make the dropdown menus in the Publications and Patenting sections consistent (closes #261).

Color the data point for the last year with full data (closes #262).

Fix unnecessary double negative in research growth stats (closes #322).