### PR TITLE
Add tooltips in jobs columns

### DIFF
--- a/web/gui-v2/package-lock.json
+++ b/web/gui-v2/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@emotion/react": "^11.11.1",
-        "@eto/eto-ui-components": "^1.7.2",
+        "@eto/eto-ui-components": "^1.8.0",
         "@mdx-js/react": "^2.3.0",
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.13.5",
@@ -2295,9 +2295,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/@eto/eto-ui-components": {
-      "version": "1.7.2",
-      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/eto-ui-components/-/@eto/eto-ui-components-1.7.2.tgz",
-      "integrity": "sha512-K0GSc/7Va0BMEABe1iK1ZkxnrRbUxr7foYcG0V8KP9tA/Ids8JKZexZRo5RY7G4Sq7Oq87tsmjobvvfsTfvD1w==",
+      "version": "1.8.0",
+      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/eto-ui-components/-/@eto/eto-ui-components-1.8.0.tgz",
+      "integrity": "sha512-yKcaiJYph+nKWryWqkGaL3yOu3S0IRCEJTDWQDzo1gRN6ts7VYLaawBVP0olthq7ZRHN2Tq4YJgmj/A6EZLHfg==",
       "dependencies": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
@@ -25495,9 +25495,9 @@
       }
     },
     "@eto/eto-ui-components": {
-      "version": "1.7.2",
-      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/eto-ui-components/-/@eto/eto-ui-components-1.7.2.tgz",
-      "integrity": "sha512-K0GSc/7Va0BMEABe1iK1ZkxnrRbUxr7foYcG0V8KP9tA/Ids8JKZexZRo5RY7G4Sq7Oq87tsmjobvvfsTfvD1w==",
+      "version": "1.8.0",
+      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/eto-ui-components/-/@eto/eto-ui-components-1.8.0.tgz",
+      "integrity": "sha512-yKcaiJYph+nKWryWqkGaL3yOu3S0IRCEJTDWQDzo1gRN6ts7VYLaawBVP0olthq7ZRHN2Tq4YJgmj/A6EZLHfg==",
       "requires": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",

--- a/web/gui-v2/package.json
+++ b/web/gui-v2/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",
-    "@eto/eto-ui-components": "^1.7.2",
+    "@eto/eto-ui-components": "^1.8.0",
     "@mdx-js/react": "^2.3.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.5",

--- a/web/gui-v2/src/components/AddRemoveColumnDialog.jsx
+++ b/web/gui-v2/src/components/AddRemoveColumnDialog.jsx
@@ -115,7 +115,7 @@ const AddRemoveColumnDialog = ({
                   disabled={colDef.key === "name"}
                 />
                 {colDef.title}
-                {colDef?.tooltip && <HelpTooltip text={colDef.tooltip} />}
+                {colDef?.tooltip && <HelpTooltip smallIcon={true} text={colDef.tooltip} />}
               </label>
             ))
           }

--- a/web/gui-v2/src/components/CellStat.jsx
+++ b/web/gui-v2/src/components/CellStat.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { css } from '@emotion/react';
+import { Warning as WarningIcon } from '@mui/icons-material';
 
+import { HelpTooltip } from '@eto/eto-ui-components';
+
+import { tooltips } from '../static_data/tooltips';
 import { commas } from '../util';
 
 const styles = {
@@ -23,13 +27,50 @@ const styles = {
       color: #a0a0a0;
     }
   `,
+  cellWithTooltip: css`
+    /* Add a column for the tooltip to fit in.  Same note as above on 3.2em. */
+    grid-template-columns: auto 1fr 3.2em;
+  `,
 };
 
 const EMPTY_VALUES = [null, '---'];
 
-const CellStat = ({data, colKey}) => {
+const tooltipTypes = {
+  "United States": {},
+  "China": {
+    text: tooltips.jobsExplanations.chinaJobs,
+    Icon: WarningIcon,
+    iconCss: css`fill: var(--orange);`,
+  },
+  "noData": {
+    text: tooltips.jobsExplanations.noData,
+    iconCss: css`fill: var(--grey);`,
+  },
+  "other": {
+    text: tooltips.jobsExplanations.otherJobs,
+    Icon: WarningIcon,
+    iconCss: css`fill: var(--orange);`,
+  },
+};
+
+const CellStat = ({
+  col,
+  country = undefined,
+  data,
+}) => {
+  const tooltipType = (country === "United States") ? undefined : (
+    (country === "China") ? "China" : (
+      (data?.total === null || data?.total === undefined) ? "noData" : (
+        country ? "other" : undefined
+      )
+    )
+  );
+
   return (
-    <div css={styles.cell}>
+    <div css={[styles.cell, tooltipType && styles.cellWithTooltip]}>
+      {tooltipType &&
+        <HelpTooltip smallIcon={true} {...tooltipTypes[tooltipType]} />
+      }
       <div className="val">
         { data?.total === null ? 'n/a' : commas(data.total) }
       </div>

--- a/web/gui-v2/src/components/ListViewTable.jsx
+++ b/web/gui-v2/src/components/ListViewTable.jsx
@@ -97,6 +97,7 @@ const styles = {
     }
   `,
   buttonBarRight: css`
+    display: flex;
     margin-left: auto;
   `,
   buttonBarButton: css`
@@ -238,7 +239,7 @@ const GROUPS_OPTIONS = Object.entries(overallData.groups)
     text: (
       tooltips?.groupExplanations?.[k] ?
         <div css={styles.dropdownEntryWithTooltip}>
-          {v.name} <HelpTooltip css={styles.groupExplanationTooltip} text={tooltips.groupExplanations[k]} />
+          {v.name} <HelpTooltip css={styles.groupExplanationTooltip} smallIcon={true} text={tooltips.groupExplanations[k]} />
         </div>
       :
         v.name

--- a/web/gui-v2/src/static_data/table_columns.js
+++ b/web/gui-v2/src/static_data/table_columns.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
+import { tooltips } from './tooltips';
 import overall from '../static_data/overall_data.json';
 import CellStat from '../components/CellStat';
 import { slugifyCompanyName } from '../util';
@@ -571,11 +572,8 @@ const columnDefinitions = [
       "ai_jobs",
       undefined, // Use default extract function
       (_val, row) => {
-        if ( row?._group || row.linkedin.length > 0 ) {
-          return <CellStat data={row.other_metrics.ai_jobs} />;
-        } else {
-          return <CellStat data={{ total: null }} />
-        }
+        const data = (row?._group || row.linkedin.length > 0) ? row.other_metrics.ai_jobs : {total: null};
+        return <CellStat col="ai_jobs" country={row.country} data={data} />;
       },
     ),
     tooltip: "Zach_tktk"
@@ -589,11 +587,8 @@ const columnDefinitions = [
       "tt1_jobs",
       undefined, // Use default extract function
       (_val, row) => {
-        if ( row?._group || row.linkedin.length > 0 ) {
-          return <CellStat data={row.other_metrics.tt1_jobs} />;
-        } else {
-          return <CellStat data={{ total: null }} />
-        }
+        const data = (row?._group || row.linkedin.length > 0) ? row.other_metrics.tt1_jobs : {total: null};
+        return <CellStat col="tt1_jobs" country={row.country} data={data} />;
       },
     ),
     initialCol: true,

--- a/web/gui-v2/src/static_data/tooltips.js
+++ b/web/gui-v2/src/static_data/tooltips.js
@@ -85,6 +85,11 @@ const tooltips = {
       </>
     ),
   },
+  jobsExplanations: {
+    chinaJobs: "zach_tktk_china",
+    otherJobs: "zach_tktk_other",
+    noData: "--zach_tktk_null--",
+  },
 };
 
 export { tooltips };


### PR DESCRIPTION
Add tooltips in the jobs columns providing explanatory information about limitations of the numbers.

Closes #326

<img src="https://github.com/georgetown-cset/parat/assets/22353962/69374625-6219-4050-ae39-1c079419bedb" width="400px" />

