### PR TITLE
Use only S&P500 in charts and remove list view decimals

### DIFF
--- a/web/gui-v2/src/components/CellStat.jsx
+++ b/web/gui-v2/src/components/CellStat.jsx
@@ -57,6 +57,7 @@ const CellStat = ({
   col,
   country = undefined,
   data,
+  isPercent = false,
 }) => {
   const tooltipType = (country === "United States") ? undefined : (
     (country === "China") ? "China" : (
@@ -72,7 +73,7 @@ const CellStat = ({
         <HelpTooltip smallIcon={true} {...tooltipTypes[tooltipType]} />
       }
       <div className="val">
-        { data?.total === null ? 'n/a' : commas(data.total) }
+        { data?.total === null ? 'n/a' : commas(data.total, { maximumFractionDigits: 0 }) }{ (data?.total !== null && data?.total !== undefined) && isPercent && "%" }
       </div>
       <div className="rank">
         { (EMPTY_VALUES.includes(data?.total)) ? '---' : (data?.rank && `#${data.rank}`) }

--- a/web/gui-v2/src/components/DetailViewPatents.jsx
+++ b/web/gui-v2/src/components/DetailViewPatents.jsx
@@ -231,10 +231,6 @@ const DetailViewPatents = ({
             "S&P 500 (average)",
             overall.groups.sp500.patents[aiSubfield].counts
           ],
-          data.groups.globalBigTech && [
-            "Global Big Tech (average)",
-            overall.groups.globalBigTech.patents[aiSubfield].counts
-          ],
         ]}
         id="ai-subfield-patents"
         layoutChanges={chartLayoutChanges}

--- a/web/gui-v2/src/components/DetailViewPublications.jsx
+++ b/web/gui-v2/src/components/DetailViewPublications.jsx
@@ -157,10 +157,6 @@ const DetailViewPublications = ({
             "S&P 500 (average)",
             overall.groups.sp500.articles[aiSubfield].counts
           ],
-          data.groups.globalBigTech && [
-            "Global Big Tech (average)",
-            overall.groups.globalBigTech.articles[aiSubfield].counts
-          ],
         ]}
         id="ai-subfield-research"
         layoutChanges={chartLayoutChanges}
@@ -191,10 +187,6 @@ const DetailViewPublications = ({
           data.groups.sp500 && [
             "S&P 500 (average)",
             overall.groups.sp500.articles.ai_pubs_top_conf.counts
-          ],
-          data.groups.globalBigTech && [
-            "Global Big Tech (average)",
-            overall.groups.globalBigTech.articles.ai_pubs_top_conf.counts
           ],
         ]}
         id="ai-top-conference-pubs-2"

--- a/web/gui-v2/src/static_data/table_columns.js
+++ b/web/gui-v2/src/static_data/table_columns.js
@@ -212,10 +212,8 @@ const columnDefinitions = [
       "ai_publications_growth",
       undefined, // Use the default extractFn
       (_val, row, _extract) => {
-        const rawVal = row.articles.ai_publications_growth;
-        const total = rawVal.total ? `${rawVal.total.toFixed(2)}%` : '---';
-        const rank = rawVal.rank;
-        return <CellStat data={{ total, rank }} />;
+        const { total, rank } = row.articles.ai_publications_growth;
+        return <CellStat data={{ total, rank }} isPercent={true} />;
       },
     ),
     isGrowthStat: true,
@@ -229,10 +227,8 @@ const columnDefinitions = [
       "ai_pubs_percent",
       undefined, // Use the default extractFn
       (_val, row, _extract) => {
-        const rawVal = row.articles.ai_pubs_percent;
-        const total = rawVal.total ? `${rawVal.total.toFixed(1)}%` : '---';
-        const rank = rawVal.rank;
-        return <CellStat data={{ total, rank }} />
+        const { total, rank } = row.articles.ai_pubs_percent;
+        return <CellStat data={{ total, rank }} isPercent={true} />
       },
     ),
     isPercent: true,
@@ -308,10 +304,8 @@ const columnDefinitions = [
       "ai_patents_growth",
       undefined, // Use the default extractFn
       (_val, row, _extract) => {
-        const rawVal = row.patents.ai_patents_growth;
-        const total = rawVal.total ? `${rawVal.total.toFixed(2)}%` : '---';
-        const rank = rawVal.rank;
-        return <CellStat data={{ total, rank }} />;
+        const { total, rank } = row.patents.ai_patents_growth;
+        return <CellStat data={{ total, rank }} isPercent={true} />;
       },
     ),
     isGrowthStat: true,
@@ -325,10 +319,8 @@ const columnDefinitions = [
       "ai_patents_percent",
       undefined, // Use the default extractFn
       (_val, row, _extract) => {
-        const rawVal = row.patents.ai_patents_percent;
-        const total = rawVal.total ? `${rawVal.total.toFixed(1)}%` : '---';
-        const rank = rawVal.rank;
-        return <CellStat data={{ total, rank }} />
+        const { total, rank } = row.patents.ai_patents_percent;
+        return <CellStat data={{ total, rank }} isPercent={true} />
       },
     ),
     isPercent: true,


### PR DESCRIPTION
Use only the S&P 500 as a comparison group in the detail view charts (closes #392). Remove decimal points from percentages in the list view (closes #399).