### PR TITLE
Add tooltip and adjust workforce section text

### DIFF
--- a/web/gui-v2/src/components/DetailViewPublications.jsx
+++ b/web/gui-v2/src/components/DetailViewPublications.jsx
@@ -86,7 +86,7 @@ const DetailViewPublications = ({
     {
       key: "ai-top-conf",
       stat: <>{commas(data.articles.ai_pubs_top_conf.total)}</>,
-      text: <>articles at top AI conferences (#{data.articles.ai_pubs_top_conf.rank} in PARAT{data.groups.sp500 && <>, #{commas(data.articles.ai_pubs_top_conf.sp500_rank)} in the S&P 500</>})</>,
+      text: <span>articles at top AI conferences (#{data.articles.ai_pubs_top_conf.rank} in PARAT{data.groups.sp500 && <>, #{commas(data.articles.ai_pubs_top_conf.sp500_rank)} in the S&P 500</>}) <HelpTooltip smallIcon={true} text={tooltips.detailView.publications.topConferencePubsChart} /></span>,
     },
     {
       key: "ai-research-percent",

--- a/web/gui-v2/src/components/DetailViewWorkforce.jsx
+++ b/web/gui-v2/src/components/DetailViewWorkforce.jsx
@@ -25,9 +25,25 @@ const DetailViewWorkforce = ({
   const otherMetricsWorkforce = [
     {
       key: 'ai_jobs',
+      description: (
+        <span>
+          From {yearSpanText}, {data.name} employed about NUMBER individuals with jobs of this type
+          (#{data.other_metrics.ai_jobs.rank} rank in PARAT
+          {data.groups.sp500 && <>, #{data.other_metrics.ai_jobs.sp500_rank} in the S&P500</>}).
+          [Revisions tktk - ai_jobs]
+        </span>
+      ),
     },
     {
       key: 'tt1_jobs',
+      description: (
+        <span>
+          From {yearSpanText}, {data.name} employed about NUMBER individuals with jobs of this type
+          (#{data.other_metrics.tt1_jobs.rank} rank in PARAT
+          {data.groups.sp500 && <>, #{data.other_metrics.tt1_jobs.sp500_rank} in the S&P500</>}).
+          [Revisions tktk - tt1_jobs]
+        </span>
+      ),
     },
   ];
 
@@ -47,15 +63,9 @@ const DetailViewWorkforce = ({
 
       {data.linkedin.length > 0 ?
         <StatWrapper>
-          { otherMetricsWorkforce.map(({ key }) => (
+          { otherMetricsWorkforce.map(({ description, key }) => (
             <StatBox
-              description={
-                <span>
-                  From {yearSpanText}, {data.name} employed about NUMBER individuals with jobs of this type 
-                  (#{data.other_metrics[key].rank} rank in PARAT
-                  {data.in_sandp_500 && <>, #NUMBER in the S&P500</>}). [Revisions tktk]
-                </span>
-              }
+              description={description}
               key={key}
               label={otherMetricMap[key]}
               value={data.other_metrics[key].total}


### PR DESCRIPTION
Repeat the AI conference pubs tooltip in the StatBox (closes #412). Adjust the handling of the workforce section's text to allow different text for each stat (closes #408).