### PR TITLE
Fix NaN and NUMBER in detail view pages

### DIFF
--- a/web/gui-v2/src/components/DetailViewPublications.jsx
+++ b/web/gui-v2/src/components/DetailViewPublications.jsx
@@ -58,6 +58,7 @@ const DetailViewPublications = ({
   const yearSpanAnd = <>{overall.years[0]} and {overall.years[overall.years.length-1]}</>;
 
   const aiResearchPercent = Math.round(1000 * data.articles.ai_publications.total / data.articles.all_publications.total) / 10;
+  const aiResearchPercentText = Number.isNaN(aiResearchPercent) ? "N/A" : `${aiResearchPercent}%`;
 
   const aiPubsGrowthTotal = commas(data.articles.ai_publications_growth.total, { maximumFractionDigits: 1 });
   const aiPubsGrowthSign = (aiPubsGrowthTotal > 0) ? '+' : '';
@@ -90,7 +91,7 @@ const DetailViewPublications = ({
     },
     {
       key: "ai-research-percent",
-      stat: <>{aiResearchPercent}%</>,
+      stat: <>{aiResearchPercentText}</>,
       text: <>of {data.name}'s total public research was AI-focused</>,
     },
   ];

--- a/web/gui-v2/src/components/DetailViewWorkforce.jsx
+++ b/web/gui-v2/src/components/DetailViewWorkforce.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
-import { Alert, HelpTooltip, ExternalLink } from '@eto/eto-ui-components';
+import { Alert, ExternalLink } from '@eto/eto-ui-components';
 
 import HeaderWithLink from './HeaderWithLink';
 import StatBox from './StatBox';
 import StatWrapper from './StatWrapper';
 import overall from '../static_data/overall_data.json';
 import { otherMetricMap } from '../static_data/table_columns';
-import { tooltips } from '../static_data/tooltips';
+import { commas } from '../util';
 
 const styles = {
   nonUScountryAlert: css`
@@ -27,7 +27,7 @@ const DetailViewWorkforce = ({
       key: 'ai_jobs',
       description: (
         <span>
-          From {yearSpanText}, {data.name} employed about NUMBER AI workers
+          From {yearSpanText}, {data.name} employed about {commas(data.other_metrics.ai_jobs.total)} AI workers
           (#{data.other_metrics.ai_jobs.rank} rank in PARAT
           {data.groups.sp500 && <>, #{data.other_metrics.ai_jobs.sp500_rank} in the S&P500</>}).
           AI workers in PARAT include anyone a high probability of working with AI. <ExternalLink href="https://eto.tech/dataset-docs/private-sector-ai-indicators/#workforce">Read more &gt;&gt;</ExternalLink>
@@ -38,7 +38,7 @@ const DetailViewWorkforce = ({
       key: 'tt1_jobs',
       description: (
         <span>
-          From {yearSpanText}, {data.name} employed about NUMBER Tech Tier 1 workers
+          From {yearSpanText}, {data.name} employed about {commas(data.other_metrics.tt1_jobs.total)} Tech Tier 1 workers
           (#{data.other_metrics.tt1_jobs.rank} rank in PARAT
           {data.groups.sp500 && <>, #{data.other_metrics.tt1_jobs.sp500_rank} in the S&P500</>}).
           Tech Tier 1 workers include anyone with technical skills and a reasonable probability of working with AI. <ExternalLink href="https://eto.tech/dataset-docs/private-sector-ai-indicators/#workforce">Read more &gt;&gt;</ExternalLink>


### PR DESCRIPTION
Say "N/A" instead of "NaN%", and add the actual number in the workforce section.

Closes #433, closes #439