### PR TITLE
Rework window sizes to resolve squished pages

### DIFF
--- a/web/gui-v2/package-lock.json
+++ b/web/gui-v2/package-lock.json
@@ -7629,9 +7629,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001579",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
-      "integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==",
+      "version": "1.0.30001636",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz",
+      "integrity": "sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg==",
       "funding": [
         {
           "type": "opencollective",
@@ -29465,9 +29465,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001579",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
-      "integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA=="
+      "version": "1.0.30001636",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz",
+      "integrity": "sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg=="
     },
     "canvas-fit": {
       "version": "1.5.0",

--- a/web/gui-v2/src/components/AddRemoveColumnDialog.jsx
+++ b/web/gui-v2/src/components/AddRemoveColumnDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import {
   Checkbox,
@@ -145,33 +145,35 @@ const AddRemoveColumnDialog = ({
       <div css={styles.columnDialogContents}>
         <div css={styles.columnDialogList}>
           {
-            COLUMN_GROUPINGS.map((colGroup) => (
-              <>
+            COLUMN_GROUPINGS.map((colGroup, ix) => (
+              <Fragment key={ix}>
                 <h3>{colGroup.heading}</h3>
                 {colGroup.entries &&
-                  colGroup.entries.map((entry) => (
+                  colGroup.entries.map((entry, ix) => (
                     <ColumnSelectionListEntry
                       colDef={entry}
                       columnsInternal={columnsInternal}
+                      key={ix}
                       setColumnsInternal={setColumnsInternal}
                     />
                   ))
                 }
                 {colGroup.subgroups &&
-                  colGroup.subgroups.map((subgroup) => (
-                    <>
+                  colGroup.subgroups.map((subgroup, ix) => (
+                    <Fragment key={ix}>
                       <h4>{subgroup.heading}</h4>
-                      {subgroup.entries.map((entry) => (
+                      {subgroup.entries.map((entry, ix) => (
                         <ColumnSelectionListEntry
                           colDef={entry}
                           columnsInternal={columnsInternal}
+                          key={ix}
                           setColumnsInternal={setColumnsInternal}
                         />
                       ))}
-                    </>
+                    </Fragment>
                   ))
                 }
-              </>
+              </Fragment>
             ))
           }
         </div>

--- a/web/gui-v2/src/util/useWindowSize.js
+++ b/web/gui-v2/src/util/useWindowSize.js
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 
+const DEFAULT_WIDTH = 1100;
+
 /**
  * Return the current width of the browser viewport.
  *
@@ -7,10 +9,16 @@ import { useEffect, useState } from 'react';
  *     updates as the user resizes the viewport.
  */
 export const useWindowSize = () => {
-  const [windowSize, setWindowSize] = useState(800);
+  const [windowSize, setWindowSize] = useState(() => {
+    if ( typeof window !== "undefined" ) {
+      return window.innerWidth;
+    } else {
+      return DEFAULT_WIDTH;
+    }
+  });
 
   useEffect(() => {
-    const handleResize = () => setWindowSize(window?.innerWidth ?? 800);
+    const handleResize = () => setWindowSize(window?.innerWidth ?? DEFAULT_WIDTH);
     if ( typeof window !== "undefined" ) {
       window.addEventListener("resize", handleResize);
     }


### PR DESCRIPTION
Rework window size detection to prevent desktop pages from loading in a "squished" state before adjusting, at the expense of mobile pages briefly showing the table of contents before it is hidden.  Closes #240.

Fix several cases of keys not being present in loops. Updated browserslist DB.

@za158 @jmelot Video showing the TOC-on-mobile situation that results from this PR:

https://github.com/georgetown-cset/parat/assets/22353962/83887329-ab6d-4d5f-b472-11f084d6482f

