### PR TITLE
Add index.html pages to the router paths

### DIFF
--- a/web/gui-v2/src/pages/company/[...].js
+++ b/web/gui-v2/src/pages/company/[...].js
@@ -95,9 +95,12 @@ const GenericPage = (props) => {
 }
 
 const FallbackPage = () => {
+  // Route URLs both with and without the `/index.html` on the end to the same
+  // components.  The `/123-FOO/index.html` pages will redirect to `/123-FOO/`.
   return (
     <Router basepath="/">
       <GenericPage path="/company/:slug" />
+      <GenericPage path="/company/:slug/index.html" />
     </Router>
   )
 };


### PR DESCRIPTION
Add cases to the Reach Router config to accomodate the `/index.html` URLs, ensuring that they are redirected appropriately to the canonical versions (`/company/123-FOO/index.html` redirects to `/company/123-FOO/`).