### PR TITLE
Add OpenGraph tags to home and detail pages

### DIFF
--- a/web/gui-v2/package-lock.json
+++ b/web/gui-v2/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@eto/eto-ui-components": "^1.8.0",
+        "@eto/social-cards": "^0.4.3",
         "@mdx-js/react": "^2.3.0",
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.13.5",
@@ -2310,6 +2311,18 @@
         "react-loadable": "^5.5.0",
         "react-plotly.js": "^2.6.0",
         "slugify": "^1.6.5"
+      }
+    },
+    "node_modules/@eto/social-cards": {
+      "version": "0.4.3",
+      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/social-cards/-/@eto/social-cards-0.4.3.tgz",
+      "integrity": "sha512-KbvznkFe5f/yspuceyxyZoHXwS+4QqvKts2UeEmjYseOf4fM8/mcJ4zaAsF5LDp4UivHE6i/ztjejnOsMJV6LA==",
+      "dependencies": {
+        "@emotion/react": "^11.11.1"
+      },
+      "peerDependencies": {
+        "@eto/eto-ui-components": "^1.4.0",
+        "gatsby-plugin-image": "^3.0.0"
       }
     },
     "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd": {
@@ -7039,13 +7052,14 @@
       }
     },
     "node_modules/babel-plugin-remove-graphql-queries": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-5.10.0.tgz",
-      "integrity": "sha512-YVjBg0RD6aHE8LOWeuDSqadOB2lPV9FeGpc32rLClaDK+wHdIPaXYqUd9ty30UY30PfB/gDclyexXlfv7qgcxA==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-5.13.1.tgz",
+      "integrity": "sha512-yncJ/W6Un48aBRpK/rmdpQOMcr4+EmJ3oi2Wq1zXKu8WLlw+j93KTbejf7fg2msm8GUskb/+9Nnpz7oMCqO9aA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@babel/types": "^7.20.7",
-        "gatsby-core-utils": "^4.10.0"
+        "gatsby-core-utils": "^4.13.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -12343,6 +12357,45 @@
         "gatsby": "^5.0.0-next",
         "react": "^18.0.0 || ^0.0.0",
         "react-dom": "^18.0.0 || ^0.0.0"
+      }
+    },
+    "node_modules/gatsby-plugin-image": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-image/-/gatsby-plugin-image-3.13.1.tgz",
+      "integrity": "sha512-v5jGXxjr//iLk7LzpW6RW/9H4KNVezxee2Sgy9mxvdvekTuFQLYoQmtk2jOZINMZMP3Vm+Rl3MqWWVMfhHuWFw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.20.13",
+        "@babel/runtime": "^7.20.13",
+        "@babel/traverse": "^7.20.13",
+        "babel-jsx-utils": "^1.1.0",
+        "babel-plugin-remove-graphql-queries": "^5.13.1",
+        "camelcase": "^6.3.0",
+        "chokidar": "^3.5.3",
+        "common-tags": "^1.8.2",
+        "fs-extra": "^11.1.1",
+        "gatsby-core-utils": "^4.13.1",
+        "gatsby-plugin-utils": "^4.13.1",
+        "objectFitPolyfill": "^2.3.5",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.3",
+        "gatsby": "^5.0.0-next",
+        "gatsby-plugin-sharp": "^5.0.0-next",
+        "gatsby-source-filesystem": "^5.0.0-next",
+        "react": "^18.0.0 || ^0.0.0",
+        "react-dom": "^18.0.0 || ^0.0.0"
+      },
+      "peerDependenciesMeta": {
+        "gatsby-plugin-sharp": {
+          "optional": true
+        },
+        "gatsby-source-filesystem": {
+          "optional": true
+        }
       }
     },
     "node_modules/gatsby-plugin-mdx": {
@@ -18273,6 +18326,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/objectFitPolyfill": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/objectFitPolyfill/-/objectFitPolyfill-2.3.5.tgz",
+      "integrity": "sha512-8Quz071ZmGi0QWEG4xB3Bv5Lpw6K0Uca87FLoLMKMWjB6qIq9IyBegP3b/VLNxv2WYvIMGoeUQ+c6ibUkNa8TA==",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -25512,6 +25572,14 @@
         "slugify": "^1.6.5"
       }
     },
+    "@eto/social-cards": {
+      "version": "0.4.3",
+      "resolved": "https://us-east1-npm.pkg.dev/gcp-cset-projects/eto-nodejs-repo/@eto/social-cards/-/@eto/social-cards-0.4.3.tgz",
+      "integrity": "sha512-KbvznkFe5f/yspuceyxyZoHXwS+4QqvKts2UeEmjYseOf4fM8/mcJ4zaAsF5LDp4UivHE6i/ztjejnOsMJV6LA==",
+      "requires": {
+        "@emotion/react": "^11.11.1"
+      }
+    },
     "@gatsbyjs/parcel-namer-relative-to-cwd": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-2.10.0.tgz",
@@ -29014,13 +29082,13 @@
       }
     },
     "babel-plugin-remove-graphql-queries": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-5.10.0.tgz",
-      "integrity": "sha512-YVjBg0RD6aHE8LOWeuDSqadOB2lPV9FeGpc32rLClaDK+wHdIPaXYqUd9ty30UY30PfB/gDclyexXlfv7qgcxA==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-5.13.1.tgz",
+      "integrity": "sha512-yncJ/W6Un48aBRpK/rmdpQOMcr4+EmJ3oi2Wq1zXKu8WLlw+j93KTbejf7fg2msm8GUskb/+9Nnpz7oMCqO9aA==",
       "requires": {
         "@babel/runtime": "^7.20.13",
         "@babel/types": "^7.20.7",
-        "gatsby-core-utils": "^4.10.0"
+        "gatsby-core-utils": "^4.13.1"
       }
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -33197,6 +33265,28 @@
         "minimatch": "^3.1.2"
       }
     },
+    "gatsby-plugin-image": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-image/-/gatsby-plugin-image-3.13.1.tgz",
+      "integrity": "sha512-v5jGXxjr//iLk7LzpW6RW/9H4KNVezxee2Sgy9mxvdvekTuFQLYoQmtk2jOZINMZMP3Vm+Rl3MqWWVMfhHuWFw==",
+      "peer": true,
+      "requires": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.20.13",
+        "@babel/runtime": "^7.20.13",
+        "@babel/traverse": "^7.20.13",
+        "babel-jsx-utils": "^1.1.0",
+        "babel-plugin-remove-graphql-queries": "^5.13.1",
+        "camelcase": "^6.3.0",
+        "chokidar": "^3.5.3",
+        "common-tags": "^1.8.2",
+        "fs-extra": "^11.1.1",
+        "gatsby-core-utils": "^4.13.1",
+        "gatsby-plugin-utils": "^4.13.1",
+        "objectFitPolyfill": "^2.3.5",
+        "prop-types": "^15.8.1"
+      }
+    },
     "gatsby-plugin-mdx": {
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-5.10.0.tgz",
@@ -37345,6 +37435,12 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
       }
+    },
+    "objectFitPolyfill": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/objectFitPolyfill/-/objectFitPolyfill-2.3.5.tgz",
+      "integrity": "sha512-8Quz071ZmGi0QWEG4xB3Bv5Lpw6K0Uca87FLoLMKMWjB6qIq9IyBegP3b/VLNxv2WYvIMGoeUQ+c6ibUkNa8TA==",
+      "peer": true
     },
     "on-finished": {
       "version": "2.4.1",

--- a/web/gui-v2/package.json
+++ b/web/gui-v2/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@eto/eto-ui-components": "^1.8.0",
+    "@eto/social-cards": "^0.4.3",
     "@mdx-js/react": "^2.3.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.5",

--- a/web/gui-v2/src/components/MetaTagsWrapper.jsx
+++ b/web/gui-v2/src/components/MetaTagsWrapper.jsx
@@ -6,7 +6,7 @@ import socialCard from '@eto/social-cards/dist/tools/parat.png';
 const MetaTagsWrapper = ({
   title = "PARAT \u2013 Emerging Technology Observatory",
   subtitle = undefined,
-  description = "ETO's tool to map high-level trends in global emerging technology research."
+  description = "ETO's hub for data on private-sector companies and their AI activities."
 }) => {
   const fullTitle = subtitle ? `${subtitle} \u2013 ${title}` : title;
 

--- a/web/gui-v2/src/components/MetaTagsWrapper.jsx
+++ b/web/gui-v2/src/components/MetaTagsWrapper.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { MetaTags } from '@eto/social-cards';
+import socialCard from '@eto/social-cards/dist/tools/parat.png';
+
+const MetaTagsWrapper = ({
+  title = "PARAT \u2013 Emerging Technology Observatory",
+  subtitle = undefined,
+  description = "ETO's tool to map high-level trends in global emerging technology research."
+}) => {
+  const fullTitle = subtitle ? `${subtitle} \u2013 ${title}` : title;
+
+  return (
+    <>
+      <title>{fullTitle}</title>
+      <MetaTags
+        title={fullTitle}
+        description={description}
+        socialCardUrl={socialCard}
+      />
+    </>
+  );
+};
+
+export default MetaTagsWrapper;

--- a/web/gui-v2/src/pages/company/{companiesJson.cset_id}-{companiesJson.name}.jsx
+++ b/web/gui-v2/src/pages/company/{companiesJson.cset_id}-{companiesJson.name}.jsx
@@ -6,6 +6,7 @@ import { AppWrapper } from '@eto/eto-ui-components';
 import DetailView from '../../components/DetailView';
 import ParatUsageDisclaimer from '../../components/ParatUsageDisclaimer';
 import { company_data as allCompanies } from '../../static_data/data';
+import MetaTagsWrapper from '../../components/MetaTagsWrapper';
 
 const CompanyPage = ({ data }) => {
   const { cset_id: companyId, name: companyName } = data.companiesJson;
@@ -36,9 +37,6 @@ export const query = graphql`
 
 export const Head = ({ pageContext }) => {
   return (
-    <>
-      <html lang="en" />
-      <title>{pageContext.name} &ndash; PARAT &ndash; Emerging Technology Observatory</title>
-    </>
+    <MetaTagsWrapper subtitle={pageContext.name} />
   );
 };

--- a/web/gui-v2/src/pages/index.js
+++ b/web/gui-v2/src/pages/index.js
@@ -9,6 +9,7 @@ import {
 } from '@eto/eto-ui-components';
 
 import ListView from '../components/ListView';
+import MetaTagsWrapper from '../components/MetaTagsWrapper';
 import ParatUsageDisclaimer from '../components/ParatUsageDisclaimer';
 
 const styles = {
@@ -65,9 +66,6 @@ export default IndexPage;
 
 export const Head = () => {
   return (
-    <>
-      <html lang="en" />
-      <title>PARAT &ndash; Emerging Technology Observatory</title>
-    </>
+    <MetaTagsWrapper />
   );
 };


### PR DESCRIPTION
Add OpenGraph tags (and the associated social cards) to the main (list view) page as well as on the individual detail pages.

Closes #460