### PR TITLE
Add full domain name with protocol for Twitter tag

### DIFF
--- a/web/gui-v2/src/components/MetaTagsWrapper.jsx
+++ b/web/gui-v2/src/components/MetaTagsWrapper.jsx
@@ -16,7 +16,7 @@ const MetaTagsWrapper = ({
       <MetaTags
         title={fullTitle}
         description={description}
-        socialCardUrl={socialCard}
+        socialCardUrl={`https://parat.eto.tech${socialCard}`}
       />
     </>
   );


### PR DESCRIPTION
Twitter requires a full URL, including protocol, not a relative path to the card image.

Closes https://github.com/georgetown-cset/eto-platform/issues/633