### PR TITLE
Format deploy script and track deployment commits

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -40,7 +40,11 @@ gatsby clean
 gatsby build
 ```
 
-And check that everything looks like you expect. Then, copy the files in the resulting `public` directory to the production GCS bucket using `bash push_to_production.sh`. This script currently rebuilds the site - you can omit the build steps if you've already run them manually. 
+And check that everything looks like you expect. Then, copy the files in the resulting `public` directory to the production GCS bucket using `bash push_to_production.sh`. This script currently rebuilds the site - you can omit the build steps if you've already run them manually.
+
+The script will also update and push the tags for the just-deployed version
+(`deploy/current`) and the previously-deployed version (`deploy/previous`) to
+help track changes.
 
 ### Tooltips
 

--- a/web/gui-v2/push_to_production.sh
+++ b/web/gui-v2/push_to_production.sh
@@ -1,1 +1,8 @@
-npm install && gatsby clean && gatsby build && gsutil -m rsync -r -d public "gs://eto-tmp/eto-parat/public" && gsutil -m -h "Cache-Control:no-cache, max-age=0" rsync -r -d "gs://eto-tmp/eto-parat/public" "gs://parat.eto.tech/"
+npm install && \
+gatsby clean && \
+gatsby build && \
+gsutil -m rsync -r -d public "gs://eto-tmp/eto-parat/public" && \
+gsutil -m -h "Cache-Control:no-cache, max-age=0" rsync -r -d "gs://eto-tmp/eto-parat/public" "gs://parat.eto.tech/" && \
+git tag --force deploy/previous deploy/current && \
+git tag --force deploy/current HEAD && \
+git push -f origin deploy/previous deploy/current


### PR DESCRIPTION
Format the deploy script so that each command is on its own line. Add commands to tag the previously-deployed and just-deployed commits and push the tags to the repo.  Add a note in the README.